### PR TITLE
Set the time_limit to Pilatus and eiger mc

### DIFF
--- a/config/cscs.py
+++ b/config/cscs.py
@@ -580,6 +580,7 @@ site_configuration = {
                     'name': 'mc',
                     'descr': 'Multicore nodes (AMD EPYC 7742, 256|512GB/cn)',
                     'scheduler': 'slurm',
+                    'time_limit': '10m',
                     'container_platforms': [
                         {
                             'type': 'Sarus',
@@ -659,6 +660,7 @@ site_configuration = {
                     'name': 'mc',
                     'descr': 'Multicore nodes (AMD EPYC 7742, 256|512GB/cn)',
                     'scheduler': 'slurm',
+                    'time_limit': '10m',
                     'container_platforms': [
                         {
                             'type': 'Sarus',


### PR DESCRIPTION
When experimenting with pilatus, my tests where being submitted with 1:00:00 wall time... The default queue time on the system is not 10 minutes