### PR TITLE
Remove `compact_test_names` from config

### DIFF
--- a/config/cscs.py
+++ b/config/cscs.py
@@ -1093,7 +1093,6 @@ site_configuration = {
         {
             'check_search_path': ['checks/'],
             'check_search_recursive': True,
-            'compact_test_names': True,
             'remote_detect': True
         }
     ]


### PR DESCRIPTION
Need to remove `compact_test_names` after https://github.com/reframe-hpc/reframe/pull/2574
Now `compact_test_names=True` is the default and only option.