### PR TITLE
Update LD_LIBRARY_PATH of cray-hdf5

### DIFF
--- a/checks/libraries/io/hdf5_compile_run.py
+++ b/checks/libraries/io/hdf5_compile_run.py
@@ -66,7 +66,7 @@ class HDF5Test(rfm.RegressionTest):
         #FIXME HPE support case 5365481562 with PrgEnv-aocc 
         if self.current_environ.name == 'PrgEnv-aocc':
             self.variables = {
-                    'LD_LIBRARY_PATH': '$CRAY_LD_LIBRARY_PATH:$LD_LIBRARY_PATH'
+                'LD_LIBRARY_PATH': '$CRAY_LD_LIBRARY_PATH:$LD_LIBRARY_PATH'
             }
 
     @run_before('compile')

--- a/checks/libraries/io/hdf5_compile_run.py
+++ b/checks/libraries/io/hdf5_compile_run.py
@@ -61,6 +61,14 @@ class HDF5Test(rfm.RegressionTest):
                 "cray-hdf5 is not supported for cdt >= 21.05 on PrgEnv-pgi"
             )
 
+    @run_after('setup')
+    def aocc(self):
+        #FIXME HPE support case 5365481562 with PrgEnv-aocc 
+        if self.current_environ.name == 'PrgEnv-aocc':
+            self.variables = {
+                    'LD_LIBRARY_PATH': '$CRAY_LD_LIBRARY_PATH:$LD_LIBRARY_PATH'
+            }
+
     @run_before('compile')
     def set_sourcepath(self):
         self.sourcepath = f'h5ex_d_chunk.{self.lang}'


### PR DESCRIPTION
I propose to add an `export` statement to update `LD_LIBRARY_PATH` with `CRAY_LD_LIBRARY_PATH` after loading `cray-hdf5` and `PrgEnv-aocc` on Alps (see the corresponding [HPE support case 5365481562](https://support.hpe.com/connect/s/case/5003f00000MOXUbAAP/cray-sh-liquid-cooled-base-system-code-hdf5-library-version-mismatched-error-with-prgenvaocc)).