### PR TITLE
Configuration for vcluster Clariden

### DIFF
--- a/config/cscs.py
+++ b/config/cscs.py
@@ -652,8 +652,76 @@ site_configuration = {
             ]
         },
         {
+            'name': 'Clariden',
+            'descr': 'Clariden AI/ML cluster',
+            'hostnames': ['clariden'],
+            'modules_system': 'lmod',
+            'partitions': [
+                {
+                    'name': 'login',
+                    'scheduler': 'local',
+                    'time_limit': '10m',
+                    'environs': [
+                        'builtin',
+                        'PrgEnv-aocc',
+                        'PrgEnv-cray',
+                        'PrgEnv-gnu',
+                        'PrgEnv-nvhpc',
+                        'PrgEnv-nvidia'
+                    ],
+                    'descr': 'Login nodes',
+                    'max_jobs': 4,
+                    'launcher': 'local'
+                },
+                {
+                    'name': 'gpu',
+                    'scheduler': 'slurm',
+                    'environs': [
+                        'builtin',
+                        'PrgEnv-aocc',
+                        'PrgEnv-cray',
+                        'PrgEnv-gnu',
+                        'PrgEnv-nvhpc',
+                        'PrgEnv-nvidia'
+                    ],
+                    'container_platforms': [
+                        {
+                            'type': 'Sarus',
+                        },
+                        {
+                            'type': 'Singularity',
+                        }
+                    ],
+                    'max_jobs': 100,
+                    'extras': {
+                        'cn_memory': 500,
+                    },
+                    'access': ['-pnvgpu'],
+                    'resources': [
+                        {
+                            'name': 'switches',
+                            'options': ['--switches={num_switches}']
+                        },
+                        {
+                            'name': 'memory',
+                            'options': ['--mem={mem_per_node}']
+                        },
+                    ],
+                    'features': ['gpu'],
+                    'devices': [
+                        {
+                            'type': 'gpu',
+                            'arch': 'sm_80',
+                            'num_devices': 4
+                        }
+                    ],
+                    'launcher': 'srun'
+                }
+            ]
+        },
+        {
             'name': 'hohgant',
-            'descr': 'Hohgant virtual cluster',
+            'descr': 'Hohgant vcluster',
             'hostnames': ['hohgant'],
             'modules_system': 'lmod',
             'partitions': [

--- a/config/cscs.py
+++ b/config/cscs.py
@@ -674,7 +674,51 @@ site_configuration = {
                     'launcher': 'local'
                 },
                 {
-                    'name': 'gpu',
+                    'name': 'amdgpu',
+                    'scheduler': 'slurm',
+                    'environs': [
+                        'builtin',
+                        'PrgEnv-aocc',
+                        'PrgEnv-cray',
+                        'PrgEnv-gnu',
+                        'PrgEnv-nvhpc',
+                        'PrgEnv-nvidia'
+                    ],
+                    'container_platforms': [
+                        {
+                            'type': 'Sarus',
+                        },
+                        {
+                            'type': 'Singularity',
+                        }
+                    ],
+                    'max_jobs': 100,
+                    'extras': {
+                        'cn_memory': 500,
+                    },
+                    'access': ['-pamdgpu'],
+                    'resources': [
+                        {
+                            'name': 'switches',
+                            'options': ['--switches={num_switches}']
+                        },
+                        {
+                            'name': 'memory',
+                            'options': ['--mem={mem_per_node}']
+                        },
+                    ],
+                    'features': ['gpu'],
+                    'devices': [
+                        {
+                            'type': 'gpu',
+                            'arch': 'mi250',
+                            'num_devices': 8
+                        }
+                    ],
+                    'launcher': 'srun'
+                },
+                {
+                    'name': 'nvgpu',
                     'scheduler': 'slurm',
                     'environs': [
                         'builtin',


### PR DESCRIPTION
I would like to add the configuration of the vcluster Clariden, which is copied from Hohgant, adding the partition `amdgpu` and renaming `gpu` as `nvgpu` (Hohgant is still configured to access only Nvidia nodes with `'access': ['-pnvgpu']`).