### PR TITLE
Reduce number of iterations

### DIFF
--- a/checks/microbenchmarks/mpi/osu/osu_tests.py
+++ b/checks/microbenchmarks/mpi/osu/osu_tests.py
@@ -118,7 +118,7 @@ class cscs_osu_pt2pt_check(cscs_osu_benchmarks):
                 self.env_vars = {'MPICH_RDMA_ENABLED_CUDA': 1}
 
         if self.current_system.name in {'arolla', 'tsa'}:
-            num_iters = 100
+            self.num_iters = 100
 
         with contextlib.suppress(KeyError):
             self.reference = self.allref[self.benchmark_info[0]][build_type]

--- a/checks/microbenchmarks/mpi/osu/osu_tests.py
+++ b/checks/microbenchmarks/mpi/osu/osu_tests.py
@@ -117,7 +117,7 @@ class cscs_osu_pt2pt_check(cscs_osu_benchmarks):
                 self.valid_prog_environs = ['PrgEnv-nvidia']
                 self.variables = {'MPICH_RDMA_ENABLED_CUDA': '1'}
 
-        if self.current_system.name in ('arolla', 'tsa'):
+        if self.current_system.name in {'arolla', 'tsa'}:
             num_iters = 100
 
         with contextlib.suppress(KeyError):

--- a/checks/microbenchmarks/mpi/osu/osu_tests.py
+++ b/checks/microbenchmarks/mpi/osu/osu_tests.py
@@ -37,6 +37,7 @@ class cscs_osu_pt2pt_check(cscs_osu_benchmarks):
     valid_systems = ['daint:gpu', 'daint:mc', 'dom:gpu', 'dom:mc',
                      'eiger:mc', 'pilatus:mc', 'arolla:cn', 'tsa:cn']
     valid_prog_environs = ['PrgEnv-gnu']
+    num_iters = 100
     benchmark_info = parameter([
         ('mpi.pt2pt.osu_bw', 'bandwidth'),
         ('mpi.pt2pt.osu_latency', 'latency')

--- a/checks/microbenchmarks/mpi/osu/osu_tests.py
+++ b/checks/microbenchmarks/mpi/osu/osu_tests.py
@@ -37,8 +37,6 @@ class cscs_osu_pt2pt_check(cscs_osu_benchmarks):
     valid_systems = ['daint:gpu', 'daint:mc', 'dom:gpu', 'dom:mc',
                      'eiger:mc', 'pilatus:mc', 'arolla:cn', 'tsa:cn']
     valid_prog_environs = ['PrgEnv-gnu']
-    if self.current_system.name in ('arolla', 'tsa'):
-        num_iters = 100
     benchmark_info = parameter([
         ('mpi.pt2pt.osu_bw', 'bandwidth'),
         ('mpi.pt2pt.osu_latency', 'latency')
@@ -118,6 +116,9 @@ class cscs_osu_pt2pt_check(cscs_osu_benchmarks):
             if self.current_system.name in ('daint', 'dom'):
                 self.valid_prog_environs = ['PrgEnv-nvidia']
                 self.variables = {'MPICH_RDMA_ENABLED_CUDA': '1'}
+
+        if self.current_system.name in ('arolla', 'tsa'):
+            num_iters = 100
 
         with contextlib.suppress(KeyError):
             self.reference = self.allref[self.benchmark_info[0]][build_type]

--- a/checks/microbenchmarks/mpi/osu/osu_tests.py
+++ b/checks/microbenchmarks/mpi/osu/osu_tests.py
@@ -37,7 +37,8 @@ class cscs_osu_pt2pt_check(cscs_osu_benchmarks):
     valid_systems = ['daint:gpu', 'daint:mc', 'dom:gpu', 'dom:mc',
                      'eiger:mc', 'pilatus:mc', 'arolla:cn', 'tsa:cn']
     valid_prog_environs = ['PrgEnv-gnu']
-    num_iters = 100
+    if self.current_system.name in ('arolla', 'tsa'):
+        num_iters = 100
     benchmark_info = parameter([
         ('mpi.pt2pt.osu_bw', 'bandwidth'),
         ('mpi.pt2pt.osu_latency', 'latency')


### PR DESCRIPTION
OSU pt2pt default value of 1000 iterations takes quite long to run; 100 iterations should be sufficient.

This modification requests lowering the number for all systems, but if preferred, a system specific limit would also be ok, I guess.