### PR TITLE
Enable 8 node runs on eiger

### DIFF
--- a/checks/apps/amber/amber_check.py
+++ b/checks/apps/amber/amber_check.py
@@ -70,7 +70,7 @@ class cscs_amber_check(amber_nve_check):
             'mpi': {
                 4: ['eiger:mc', 'pilatus:mc'],
                 6: ['daint:mc', 'dom:mc'],
-                8: ['pilatus:mc'],
+                8: ['eiger:mc', 'pilatus:mc'],
                 16: ['daint:mc']
             }
         }


### PR DESCRIPTION
This includes the Amber checks with 8 nodes to the Eiger cluster.