### PR TITLE
Update environment checks for Pilatus

### DIFF
--- a/checks/prgenv/environ_check.py
+++ b/checks/prgenv/environ_check.py
@@ -22,7 +22,7 @@ class DefaultPrgEnvCheck(rfm.RunOnlyRegressionTest):
 
     @run_after('init')
     def load_cray_module(self):
-        if self.current_system.name in ['hohgant']:
+        if self.current_system.name in ['hohgant', 'pilatus']:
             self.modules = ['cray']
 
     @run_before('sanity')
@@ -102,7 +102,7 @@ class CrayVariablesCheckEiger(CrayVariablesCheck):
 
     @run_after('init')
     def load_cray_module(self):
-        if self.current_system.name in ['hohgant']:
+        if self.current_system.name in ['hohgant', 'pilatus']:
             self.modules = ['cray']
 
     @run_after('init')


### PR DESCRIPTION
I provide an updated check for Pilatus after the recent change of configuration of ReFrame to match the new environment on the system: the change should fix the tests `CrayVariablesCheckEiger` that are [currently failing in the daily run](https://jenkins.cscs.ch/blue/organizations/jenkins/reframe-pilatus-production-daily/detail/reframe-pilatus-production-daily/652/pipeline/).