### PR TITLE
Add cray module to load singularity

### DIFF
--- a/checks/containers/buildah/buildah_check.py
+++ b/checks/containers/buildah/buildah_check.py
@@ -183,6 +183,11 @@ class ContainerMpichOSUTest(rfm.RunOnlyRegressionTest):
     def set_dependencies(self):
         self.depends_on('BuildahMpichOSUTest')
 
+    def load_cray_module(self):
+        if self.current_system.name in ['pilatus']:
+            self.modules = ['cray']
+
+
     @run_after('setup')
     def config_container_platform(self):
         self.container_platform = self.platform

--- a/checks/containers/buildah/buildah_check.py
+++ b/checks/containers/buildah/buildah_check.py
@@ -183,12 +183,6 @@ class ContainerMpichOSUTest(rfm.RunOnlyRegressionTest):
     def set_dependencies(self):
         self.depends_on('BuildahMpichOSUTest')
 
-    @run_after('init')
-    def load_cray_module(self):
-        if self.current_system.name in ['pilatus']:
-            self.modules = ['cray']
-
-
     @run_after('setup')
     def config_container_platform(self):
         self.container_platform = self.platform

--- a/checks/containers/buildah/buildah_check.py
+++ b/checks/containers/buildah/buildah_check.py
@@ -183,6 +183,7 @@ class ContainerMpichOSUTest(rfm.RunOnlyRegressionTest):
     def set_dependencies(self):
         self.depends_on('BuildahMpichOSUTest')
 
+    @run_after('init')
     def load_cray_module(self):
         if self.current_system.name in ['pilatus']:
             self.modules = ['cray']

--- a/config/systems/pilatus.py
+++ b/config/systems/pilatus.py
@@ -44,7 +44,7 @@ base_config = {
                 },
                 {
                     'type': 'Singularity',
-                    'modules': ['singularity/3.5.3-eiger']
+                    'modules': ['cray', 'singularity/3.5.3-eiger']
                 }
             ],
             'environs': [


### PR DESCRIPTION
The check `ContainerMpichOSUTest` fails on Pilatus in the [daily run of the regression test suite](https://jenkins.cscs.ch/blue/organizations/jenkins/reframe-pilatus-production-daily/detail/reframe-pilatus-production-daily/656/pipeline):
```
Lmod Warning: Failed to find the following module(s):
"singularity/3.5.3-eiger" in your MODULEPATH

Try:
    $ module spider singularity/3.5.3-eiger
to see if the module(s) are available across all compilers and MPI implementations.
```
The reason is that the module `cray` is not loaded, since the module `singularity` is not created in a toolchain with a `PrgEnv` modulefile: therefore I am adding the request to load the module `cray` in the initialization of the check.