### PR TITLE
Fix cray module for IOR and PrgEnv checks

### DIFF
--- a/checks/prgenv/environ_check.py
+++ b/checks/prgenv/environ_check.py
@@ -22,7 +22,7 @@ class DefaultPrgEnvCheck(rfm.RunOnlyRegressionTest):
 
     @run_after('init')
     def load_cray_module(self):
-        if self.current_system.name in ['hohgant', 'pilatus']:
+        if self.current_system.name in ['hohgant', 'eiger', 'pilatus']:
             self.modules = ['cray']
 
     @run_before('sanity')
@@ -102,7 +102,7 @@ class CrayVariablesCheckEiger(CrayVariablesCheck):
 
     @run_after('init')
     def load_cray_module(self):
-        if self.current_system.name in ['hohgant', 'pilatus']:
+        if self.current_system.name in ['hohgant', 'eiger', 'pilatus']:
             self.modules = ['cray']
 
     @run_after('init')

--- a/checks/system/io/ior_check.py
+++ b/checks/system/io/ior_check.py
@@ -112,7 +112,7 @@ class IorCheck(rfm.RegressionTest):
 
     @run_after('init')
     def load_cray_module(self):
-        if self.current_system.name in ['pilatus']:
+        if self.current_system.name in ['eiger', 'pilatus']:
             self.modules = ['cray']
 
     @run_before('compile')


### PR DESCRIPTION
I provide a fix for the regression tests that need to load the module `cray` on Eiger after the last maintenance.