### PR TITLE
Use the new slurm plugin convention for uenvs

### DIFF
--- a/config/cscs.py
+++ b/config/cscs.py
@@ -10,8 +10,8 @@ import os
 from reframe.utility import import_module_from_file
 
 
-uenv_file = os.environ.get('UENV_FILE', None)
-systems_path = 'systems-uenv' if uenv_file is not None else 'systems'
+uenv = os.environ.get('UENV', None)
+systems_path = 'systems-uenv' if uenv is not None else 'systems'
 
 system_conf_files = glob.glob(
     os.path.join(os.path.dirname(__file__), systems_path, '*.py')


### PR DESCRIPTION
This PR makes the following changes:

1. The `UENV` variable is used to pass user environments to ReFrame, which uses the following convention, ` --uenv=<file>[:mount-point][,<file:mount-point>]*`
2. Only the first image/mount pair of `UENV` is used
3. The mount point of the uenv and the activation script have to coincide 