### PR TITLE
Updated Sarus MPI checks using SSH

### DIFF
--- a/checks/containers/sarus/check_osu_benchmarks.py
+++ b/checks/containers/sarus/check_osu_benchmarks.py
@@ -89,7 +89,7 @@ class SarusOSULatencyWithSshLauncher(BaseCheck):
     def setup_container_platform(self):
         self.container_platform.image = self.sarus_image
         self.container_platform.options = [
-            '--mount=src=$SCRATCH,dst=$SCRATCH,type=bind',
+            '--mount=src=${SCRATCH:-/scratch},dst=${SCRATCH:-/scratch},type=bind',
             '--ssh'
         ]
         self.container_platform.command  = (

--- a/checks/containers/sarus/check_osu_benchmarks.py
+++ b/checks/containers/sarus/check_osu_benchmarks.py
@@ -89,7 +89,7 @@ class SarusOSULatencyWithSshLauncher(BaseCheck):
     def setup_container_platform(self):
         self.container_platform.image = self.sarus_image
         self.container_platform.options = [
-            '--mount=src=/scratch,dst=/scratch,type=bind',
+            '--mount=src=$SCRATCH,dst=$SCRATCH,type=bind',
             '--ssh'
         ]
         self.container_platform.command  = (


### PR DESCRIPTION
Not all clusters have the scratch filesystem mounted to `/scratch`, so the `$SCRATCH` environment variable should be used when defining the bind mount option. This is also consistent with the bash commands being executed in the container.