### PR TITLE
[test] Fix IOR on Alps with capstor

### DIFF
--- a/checks/system/io/ior_check.py
+++ b/checks/system/io/ior_check.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright 2016-2023 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/system/io/ior_check.py
+++ b/checks/system/io/ior_check.py
@@ -11,7 +11,7 @@ import reframe.utility.sanity as sn
 
 
 class IorCheck(rfm.RegressionTest):
-    base_dir = parameter(['/capstor/scratch/cscs',
+    base_dir = parameter(['${SCRATCH:-/captor/scratch/cscs}',
                           '/scratch/snx3000tds',
                           '/scratch/snx3000',
                           '/scratch/shared/fulen',

--- a/checks/system/io/ior_check.py
+++ b/checks/system/io/ior_check.py
@@ -32,7 +32,7 @@ class IorCheck(rfm.RegressionTest):
     @run_after('init')
     def set_fs_information(self):
         self.fs = {
-            '/capstor/scratch/cscs': {
+            ''${SCRATCH:-/captor/scratch/cscs}': {
                 'valid_systems': ['eiger:mc', 'pilatus:mc'],
                 'eiger': {
                     'num_tasks': 10,

--- a/checks/system/io/ior_check.py
+++ b/checks/system/io/ior_check.py
@@ -11,7 +11,7 @@ import reframe.utility.sanity as sn
 
 
 class IorCheck(rfm.RegressionTest):
-    base_dir = parameter(['/scratch/e1000',
+    base_dir = parameter(['/capstor/scratch/cscs',
                           '/scratch/snx3000tds',
                           '/scratch/snx3000',
                           '/scratch/shared/fulen',
@@ -32,7 +32,7 @@ class IorCheck(rfm.RegressionTest):
     @run_after('init')
     def set_fs_information(self):
         self.fs = {
-            '/scratch/e1000': {
+            '/capstor/scratch/cscs': {
                 'valid_systems': ['eiger:mc', 'pilatus:mc'],
                 'eiger': {
                     'num_tasks': 10,


### PR DESCRIPTION
The current `/scratch/e1000` hosted on `alpstor` will be read-only as of Oct 25th, therefore the check would fail to write there. I have provided the new path to the `capstor` scratch: it would be better to use the environment variable `$SCRATCH`, if possible.