### PR TITLE
[test] Fix IOR check

### DIFF
--- a/checks/system/io/ior_check.py
+++ b/checks/system/io/ior_check.py
@@ -11,7 +11,7 @@ import reframe.utility.sanity as sn
 
 
 class IorCheck(rfm.RegressionTest):
-    base_dir = parameter(['${SCRATCH:-/captor/scratch/cscs}',
+    base_dir = parameter(['/capstor/scratch/cscs',
                           '/scratch/snx3000tds',
                           '/scratch/snx3000',
                           '/scratch/shared/fulen',
@@ -32,7 +32,7 @@ class IorCheck(rfm.RegressionTest):
     @run_after('init')
     def set_fs_information(self):
         self.fs = {
-            ''${SCRATCH:-/captor/scratch/cscs}': {
+            '/capstor/scratch/cscs': {
                 'valid_systems': ['eiger:mc', 'pilatus:mc'],
                 'eiger': {
                     'num_tasks': 10,


### PR DESCRIPTION
The change recently merged in #130 raised a syntax error, therefore  I am reverting back to the absolute path:
```
ERROR: run session stopped: syntax error: invalid syntax (ior_check.py, line 35)

  File "/users/lucamar/GitHub/lucamar/cscs-reframe-tests/checks/system/io/ior_check.py", line 35
    ''${SCRATCH:-/capstor/scratch/cscs}': {
      ^
SyntaxError: invalid syntax
```