### PR TITLE
[test] Add cpeGNU environment for ParaView

### DIFF
--- a/checks/apps/paraview/paraview_check.py
+++ b/checks/apps/paraview/paraview_check.py
@@ -23,7 +23,7 @@ class ParaViewCheck(rfm.RunOnlyRegressionTest):
     @run_after('init')
     def set_prgenv_alps(self):
         if self.current_system.name in {'eiger', 'pilatus'}:
-            self.valid_prog_environs = ['cpeCray']
+            self.valid_prog_environs = ['cpeCray', 'cpeGNU']
 
     @sanity_function
     def assert_vendor_renderer(self):


### PR DESCRIPTION
We currently test `ParaView` only using `cpeCray`, while the latest module is built with `cpeGNU`.