### PR TITLE
Update path of resources folder on Eiger

### DIFF
--- a/config/systems/eiger.py
+++ b/config/systems/eiger.py
@@ -12,7 +12,7 @@ import copy
 
 base_config = {
     'modules_system': 'lmod',
-    'resourcesdir': '/apps/common/UES/reframe/resources',
+    'resourcesdir': '/capstor/apps/cscs/common/regression/resources',
     'partitions': [
         {
             'name': 'login',


### PR DESCRIPTION
The current path under `/apps/common` won't be accessible any longer on Eiger.