### PR TITLE
Improve the firecrest sched docs

### DIFF
--- a/config/cscs.py
+++ b/config/cscs.py
@@ -19,7 +19,14 @@ import firecrest_slurm
 
 firecrest = os.environ.get('RFM_FIRECREST', None)
 uenv = os.environ.get('UENV', None)
-systems_path = 'systems-firecrest' if firecrest is not None else 'systems-uenv' if uenv is not None else 'systems'
+
+def is_var_true(var):
+    if var is None:
+        return False
+
+    return var.lower() in ['true', 'yes', '1']
+
+systems_path = 'systems-firecrest' if is_var_true(firecrest) else 'systems-uenv' if is_var_true(uenv) else 'systems'
 
 system_conf_files = glob.glob(
     os.path.join(os.path.dirname(__file__), systems_path, '*.py')

--- a/config/cscs.py
+++ b/config/cscs.py
@@ -17,15 +17,14 @@ sys.path.append(utilities_path)
 import firecrest_slurm
 
 
-firecrest = os.environ.get('RFM_FIRECREST', None)
-uenv = os.environ.get('UENV', None)
-
 def is_var_true(var):
     if var is None:
         return False
 
     return var.lower() in ['true', 'yes', '1']
 
+firecrest = os.environ.get('RFM_FIRECREST', None)
+uenv = os.environ.get('UENV', None)
 systems_path = 'systems-firecrest' if is_var_true(firecrest) else 'systems-uenv' if is_var_true(uenv) else 'systems'
 
 system_conf_files = glob.glob(

--- a/config/systems-firecrest/README.md
+++ b/config/systems-firecrest/README.md
@@ -28,7 +28,7 @@ FIRECREST_SYSTEM=daint
 FIRECREST_BASEDIR=
 
 # In case the tests need compilation you have to pass this in the command in order to build them in the remote partitions
-reframe ... -Sbuild_locally=0
+reframe -C /path/to/cscs-reframe-tests/config/cscs.py ... -Sbuild_locally=0
 ```
 
 The processor autodetection can be really slow, so we recommend to skip it for now. It also requires a version of Reframe with this bugfix: https://github.com/reframe-hpc/reframe/pull/3094


### PR DESCRIPTION
As Andreas noticed, the way we are testing now the vars to decide which configs to import can be a bit confusing. They are always true when set. `RFM_FIRECREST=0` is equivalent to `RFM_FIRECREST=1`.