### PR TITLE
Fix F90 build with gcc/12.2.0 on Pilatus

### DIFF
--- a/checks/tools/profiling_and_debugging/notool.py
+++ b/checks/tools/profiling_and_debugging/notool.py
@@ -66,7 +66,7 @@ class JacobiNoToolHybrid(rfm.RegressionTest):
             'PrgEnv-cray': ['-O2', '-g',
                             '-homp' if self.lang == 'F90' else '-fopenmp'],
             'PrgEnv-gnu': ['-O2', '-g', '-fopenmp',
-                            '-fallow-argument-mismatch' if self.lang == 'F90' else ''],
+                           '-fallow-argument-mismatch' if self.lang == 'F90' else ''],
             'PrgEnv-intel': ['-O2', '-g', '-qopenmp'],
             'PrgEnv-pgi': ['-O2', '-g', '-mp'],
             'PrgEnv-nvidia': ['-O2', '-g', '-mp']


### PR DESCRIPTION
The Fortran build [fails on Pilatus](https://jenkins.cscs.ch/blue/organizations/jenkins/reframe-pilatus-production-daily/detail/reframe-pilatus-production-daily/936/pipeline/) using the default `gcc/12.2.0` of `PrgEnv-gnu` (see [SPCI-235](https://jira.cscs.ch/browse/SPCI-235) as well): I provide a fix using the flag `'-fallow-argument-mismatch'`.