### PR TITLE
Fix performance reference with COS 2.4 on Pilatus

### DIFF
--- a/checks/microbenchmarks/cpu/alloc_speed/alloc_speed.py
+++ b/checks/microbenchmarks/cpu/alloc_speed/alloc_speed.py
@@ -62,7 +62,7 @@ class AllocSpeedTest(rfm.RegressionTest):
                     'time': (0.12, None, 0.15, 's')
                 },
                 'pilatus:mc': {
-                    'time': (0.12, None, 0.15, 's')
+                    'time': (0.14, None, 0.15, 's')
                 },
             },
             '2M': {
@@ -82,7 +82,7 @@ class AllocSpeedTest(rfm.RegressionTest):
                     'time': (0.06, None, 0.15, 's')
                 },
                 'pilatus:mc': {
-                    'time': (0.06, None, 0.15, 's')
+                    'time': (0.07, None, 0.15, 's')
                 },
                 '*': {
                     'time': (0, None, None, 's')


### PR DESCRIPTION
The test [fails the performance check](https://jenkins.cscs.ch/blue/organizations/jenkins/reframe-pilatus-production-daily/detail/reframe-pilatus-production-daily/936/pipeline/) with the Cray Operating System 2.4 on Pilatus: therefore I provide an updated and slightly degraded performance reference to meet the new reference value.