### PR TITLE
Fix NAMD CPU threads with Slurm 23.02.7

### DIFF
--- a/checks/apps/namd/namd_check.py
+++ b/checks/apps/namd/namd_check.py
@@ -58,6 +58,7 @@ class NamdCheck(rfm.RunOnlyRegressionTest):
             # On Eiger a no-smp NAMD version is the default
             if self.current_system.name in ['eiger', 'pilatus']:
                 self.executable_opts = ['+idlepoll', 'stmv.namd']
+                self.num_cpus_per_task = 2
             else:
                 self.executable_opts = ['+idlepoll', '+ppn 71', 'stmv.namd']
                 self.num_cpus_per_task = 72
@@ -76,12 +77,6 @@ class NamdCheck(rfm.RunOnlyRegressionTest):
             else:
                 self.num_tasks = 16
                 self.num_tasks_per_node = 1
-
-        # Fix threads per task on Pilatus with Slurm 23.02.7
-        if self.current_system.name in ['pilatus']:
-            self.env_vars = {
-                'SRUN_CPUS_PER_TASK': '2'
-            }
 
     @run_before('compile')
     def prepare_build(self):
@@ -128,7 +123,7 @@ class NamdCheck(rfm.RunOnlyRegressionTest):
                 self.reference = {
                     'daint:mc': {'days_ns': (0.425, None, 0.10, 'days/ns')},
                     'eiger:mc': {'days_ns': (0.057, None, 0.05, 'days/ns')},
-                    'pilatus:mc': {'days_ns': (0.054, None, 0.05, 'days/ns')}
+                    'pilatus:mc': {'days_ns': (0.054, None, 0.10, 'days/ns')}
                 }
 
     @performance_function('days/ns')

--- a/checks/apps/namd/namd_check.py
+++ b/checks/apps/namd/namd_check.py
@@ -77,6 +77,12 @@ class NamdCheck(rfm.RunOnlyRegressionTest):
                 self.num_tasks = 16
                 self.num_tasks_per_node = 1
 
+        # Fix threads per task on Pilatus with Slurm 23.02.7
+        if self.current_system.name in ['pilatus']:
+            self.env_vars = {
+                'SRUN_CPUS_PER_TASK': '2'
+            }
+
     @run_before('compile')
     def prepare_build(self):
         # Reset sources dir relative to the SCS apps prefix


### PR DESCRIPTION
I provide a fix for the `NAMD` regression check on Pilatus with Slurm 23.02.7 setting `SRUN_CPUS_PER_TASK`: see [SPCI-235](https://jira.cscs.ch/browse/SPCI-235).