### PR TITLE
Workaround for CrayVariablesCheckEiger with CPE 23.12

### DIFF
--- a/checks/prgenv/environ_check.py
+++ b/checks/prgenv/environ_check.py
@@ -94,9 +94,9 @@ class CrayVariablesCheckDaint(CrayVariablesCheck):
 @rfm.simple_test
 class CrayVariablesCheckEiger(CrayVariablesCheck):
     cray_module = parameter([
-        'cray-fftw', 'cray-hdf5', 'cray-hdf5-parallel', 'cray-libsci',
+        'cray-fftw', 'cray-hdf5', 'cray-hdf5-parallel',
         'cray-mpich', 'cray-openshmemx', 'cray-parallel-netcdf', 'cray-pmi',
-        'cray-python', 'cray-R', 'gcc', 'papi'
+        'cray-python', 'cray-R', 'papi'
     ])
     valid_systems = ['eiger:login', 'pilatus:login', 'hohgant:login']
 
@@ -108,5 +108,5 @@ class CrayVariablesCheckEiger(CrayVariablesCheck):
     @run_after('init')
     def skip_modules(self):
         # FIXME: These modules should be fixed in later releases
-        if self.cray_module in {'cray-fftw', 'cray-python'}:
+        if self.cray_module in {'cray-fftw', 'cray-libsci', 'cray-python'}:
             self.valid_systems = []


### PR DESCRIPTION
CPE 23.12 replaced the environment variable `CRAY_LIBSCI_PREFIX_DIR` with `CRAY_PE_LIBSCI_PREFIX` and `CRAY_PE_LIBSCI_PREFIX_DIR` in the modulefile `cray-libsci`. 
Additionally, the name of the `gcc` module loaded by `PrgEnv-gnu` is now `gcc-native` (see [SPCI-236](https://jira.cscs.ch/browse/SPCI-236) for more details).

Therefore, the sanity patterns `{envvar_prefix}_PREFIX` and `{envvar_prefix}_VERSION` using `envvar_prefix = self.cray_module.upper().replace('-', '_')` do not work any longer for `CrayVariablesCheckEiger`, since the envvar prefix should be `CRAY_PE_LIBSCI` for `cray-libsci` and `GCC` only for `gcc-native`.

I am providing a quick workaround that simply skips the check of `cray-libsci` and `gcc` for the time being. 