### PR TITLE
Update tolerance of MemoryOverconsumptionMpiCheck

### DIFF
--- a/checks/system/slurm/slurm.py
+++ b/checks/system/slurm/slurm.py
@@ -271,7 +271,7 @@ class MemoryOverconsumptionMpiCheck(SlurmCompiledBaseCheck):
         reference_mem = self.current_partition.extras['cn_memory'] - 3
         self.reference = {
             '*': {
-                'cn_max_allocated_memory': (reference_mem, -0.05, None, 'GB'),
+                'cn_max_allocated_memory': (reference_mem, -0.10, None, 'GB'),
             }
         }
 


### PR DESCRIPTION
The test `MemoryOverconsumptionMpiCheck` often [fails to meet the expected performance](https://jenkins.cscs.ch/blue/organizations/jenkins/reframe-pilatus-production-daily/detail/reframe-pilatus-production-daily/993/pipeline) with `PrgEnv-cray` and `PrgEnv-gnu` on Pilatus with CPE 23.12 and COS 3.0. 
I suggest to increase the tolerance to 10% below the reference value, which will make the test pass on Pilatus as well.