### PR TITLE
New pytorch test that checks against the latest available nvidia image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__/
 *.log
 *.out
 *.swp
+.venv

--- a/README.md
+++ b/README.md
@@ -28,3 +28,18 @@ You can then list all the tests on any CSCS supported machine as follows:
 ```
 reframe -C config/cscs.py -c checks/ -R -l
 ```
+
+
+## Set-up Python Virtual environement
+
+Install python3.12 on your machine.
+
+Create a virtual environment:
+```console
+python3.12 -m venv .venv
+source .venv/bin/activate
+python3 -m pip install --upgrade pip
+pip install -r requirements.txt
+
+
+## Debug 

--- a/checks/apps/pytorch/pytorch_nvidia_latest.py
+++ b/checks/apps/pytorch/pytorch_nvidia_latest.py
@@ -1,0 +1,65 @@
+import reframe as rfm
+import reframe.utility.sanity as sn
+from pytorch_test_base import PyTorchTestBase
+import requests
+import re
+from packaging.version import Version
+import pathlib
+pathlib.Path(__file__).parent
+from pytorch_nvidia import PyTorchDdpCeNv  # noqa: E402
+
+
+def latest_nvidia_pytorch_image_tags():
+
+    token_response = requests.get("https://nvcr.io/proxy_auth?scope=repository:nvidia/pytorch:pull,push")
+
+
+    tags_url = "https://nvcr.io/v2/nvidia/pytorch/tags/list?n=5"
+    headers = {
+        "Authorization": f"Bearer {token_response.json().get('token')}"
+    }
+
+    image_tags_response = requests.get(tags_url, headers=headers)
+
+    tags = image_tags_response.json().get("tags", [])
+    versions = [re.search(r"^(\d+\.\d+)-.+$", tag, re.IGNORECASE).group(1) for tag in tags if re.match(r"^\d+\.\d+-.+$", tag)]
+    latest_version = sorted(versions, key=Version, reverse=True)[0]
+    latest_tags = [tag for tag in tags if tag.startswith(latest_version)]
+
+    return latest_tags
+
+
+@rfm.simple_test
+class version_test(rfm.RunOnlyRegressionTest):
+    valid_systems = ['*']
+    valid_prog_environs = ['*']
+    executable = 'echo "hello"'
+
+    @sanity_function
+    def validate(self):
+        return sn.assert_found(r'hello', self.stdout)
+    
+    @run_before('run')
+    def set_container_variables(self):
+        tags = latest_nvidia_pytorch_image_tags()
+        print(tags)
+            
+
+
+
+@rfm.simple_test
+class PyTorchDdpSarus(PyTorchTestBase):
+    valid_systems = ['+nvgpu +sarus']
+    platform = 'Sarus'
+
+    @run_before('run')
+    def set_container_variables(self):
+        self.container_platform = self.platform
+        self.container_platform.command = self.executable
+        self.container_platform.image = parameter(["nvcr.io/nvidia/pytorch:" + tag for tag in latest_nvidia_pytorch_image_tags()])
+        self.job.launcher.options.append('--mpi=pmi2')
+
+@rfm.simple_test
+class PyTorchDdpCeNvLatest(PyTorchDdpCeNv):
+    image = parameter(["nvcr.io/nvidia/pytorch:" + tag for tag in latest_nvidia_pytorch_image_tags()])
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+reframe
+pyfirecrest==2.5.0
+python-hostlist==1.23.0


### PR DESCRIPTION
!!Work in progress!!

This test extends the pytorch_nvidia.py test and adds the ability to dynamically fetch the latest available nvidia image.

TODO:
-consider merging pytorch_nvidia.py and pytorch_nvidia_latest.py
-validate the type of image to be used
-add exception handling
-clean up code

Bonus:
This PR also adds documentation and config to help with local code debugging.