### PR TITLE
Fix SyntaxError

### DIFF
--- a/checks/apps/gromacs/gromacs_check.py
+++ b/checks/apps/gromacs/gromacs_check.py
@@ -106,9 +106,9 @@ class gromacs_build_test(rfm.CompileOnlyRegressionTest):
 @rfm.simple_test
 class gromacs_run_test(rfm.RunOnlyRegressionTest):
     executable = './mps-wrapper.sh -- gmx_mpi mdrun -s topol.tpr'
-    executable_opts = ['-dlb no', '-ntomp 32', '-pme gpu', '-npme 1', '-bonded
-                       gpu', '-nb gpu', '-nsteps 10000', '-update gpu', '-pin
-                       off', '-v', '-noconfout', '-nstlist 300']
+    executable_opts = ['-dlb no', '-ntomp 32', '-pme gpu', '-npme 1',
+                       '-bonded gpu', '-nb gpu', '-nsteps 10000', '-update gpu',
+                       '-pin off', '-v', '-noconfout', '-nstlist 300']
     maintainers = ['SSA']
     valid_systems = ['*']
     test_name = variable(str, value='STMV')


### PR DESCRIPTION
Fix SyntaxError in `checks/apps/gromacs/gromacs_check.py` 
