### PR TITLE
Add missing comma in daint configuration

### DIFF
--- a/config/systems/daint.py
+++ b/config/systems/daint.py
@@ -82,10 +82,11 @@ site_configuration = {
     'environments': [
         {
             'name': 'PrgEnv-cray',
-            'features': ['serial', 'openmp', 'mpi', 'cuda', 'openacc', 'hdf5',
-                         'netcdf-hdf5parallel',
-                         #FIXME MPI Error when using pnetcdf
-                         # 'pnetcdf'
+            'features': [
+                'serial', 'openmp', 'mpi', 'cuda', 'openacc', 'hdf5',
+                'netcdf-hdf5parallel',
+                # FIXME MPI Error when using pnetcdf
+                # 'pnetcdf'
             ],
             'target_systems': ['daint'],
             'modules': ['cray', 'PrgEnv-cray', 'craype-arm-grace']
@@ -93,11 +94,12 @@ site_configuration = {
         {
             'name': 'PrgEnv-gnu',
             'target_systems': ['daint'],
-            'features': ['serial', 'openmp', 'mpi', 'cuda', 'alloc_speed',
-                         'hdf5', 'netcdf-hdf5parallel',
-                         #FIXME MPI Error when using pnetcdf
-                         # 'pnetcdf'
-            ]
+            'features': [
+                'serial', 'openmp', 'mpi', 'cuda', 'alloc_speed',
+                'hdf5', 'netcdf-hdf5parallel',
+                # FIXME MPI Error when using pnetcdf
+                # 'pnetcdf'
+            ],
             'modules': ['cray', 'PrgEnv-gnu', 'craype-arm-grace']
         },
         {
@@ -137,5 +139,5 @@ site_configuration = {
            ],
            'target_systems': ['daint'],
        }
-   ]
+    ]
 }


### PR DESCRIPTION
The important change is the comma missing in the `PrgEnv-gnu` environment. But I also fixed a bit the formatting because my editor was complaining.