### PR TITLE
Use longer gitlab runner timelimit in firecrest CI configurations

### DIFF
--- a/ci/alps_cpe.yml
+++ b/ci/alps_cpe.yml
@@ -9,6 +9,9 @@ stages:
 reframe:
   stage: run
   extends: .f7t-baremetal-runner
+  timeout: 8 hours
+  variables:
+    SLURM_TIMELIMIT: '00:60:00'
   before_script:
     - echo "FIRECREST_SYSTEM=$FIRECREST_SYSTEM / F7T_URL=$F7T_URL / CLUSTER_NAME=$CLUSTER_NAME"
     - uname -a

--- a/ci/alps_cpe.yml
+++ b/ci/alps_cpe.yml
@@ -11,7 +11,7 @@ reframe:
   extends: .f7t-baremetal-runner
   timeout: 8 hours
   variables:
-    SLURM_TIMELIMIT: '00:60:00'
+    SLURM_TIMELIMIT: '02:00:00'
   before_script:
     - echo "FIRECREST_SYSTEM=$FIRECREST_SYSTEM / F7T_URL=$F7T_URL / CLUSTER_NAME=$CLUSTER_NAME"
     - uname -a

--- a/ci/alps_uenv.yml
+++ b/ci/alps_uenv.yml
@@ -55,7 +55,7 @@ reframe:
   extends: .f7t-baremetal-runner
   timeout: 8 hours
   variables:
-    SLURM_TIMELIMIT: '00:60:00'
+    SLURM_TIMELIMIT: '02:00:00'
   needs: ['setup and pull']
   before_script:
     - echo "FIRECREST_SYSTEM=$FIRECREST_SYSTEM / F7T_URL=$F7T_URL / CLUSTER_NAME=$CLUSTER_NAME"

--- a/ci/alps_uenv.yml
+++ b/ci/alps_uenv.yml
@@ -10,7 +10,9 @@ stages:
 setup and pull:
   stage: pull
   extends: .f7t-baremetal-runner
-  # variables:
+  timeout: 8 hours
+  variables:
+    SLURM_TIMELIMIT: '00:10:00'
     # Valid MODE=('container-runner', 'baremetal', 'f7t-controller')
   before_script:
     - echo "FIRECREST_SYSTEM=$FIRECREST_SYSTEM / F7T_URL=$F7T_URL / CLUSTER_NAME=$CLUSTER_NAME"
@@ -51,6 +53,9 @@ setup and pull:
 reframe:
   stage: run
   extends: .f7t-baremetal-runner
+  timeout: 8 hours
+  variables:
+    SLURM_TIMELIMIT: '00:60:00'
   needs: ['setup and pull']
   before_script:
     - echo "FIRECREST_SYSTEM=$FIRECREST_SYSTEM / F7T_URL=$F7T_URL / CLUSTER_NAME=$CLUSTER_NAME"


### PR DESCRIPTION
Currently the slurm timelimit and the gitlab runner timeout are set to the default one hour.

Sometimes the queueing time can be longer than one hour, even if the slurm job itself could finish in less than an hour. For example, in https://gitlab.com/cscs-ci/ci-testing/webhook-ci/mirrors/6557018579987861/835515875116214/-/jobs/9549784370 the job was submitted and queued, but the gitlab job timed out after one hour with the job still in the queue.

This PR explicitly sets a longer, 8 hour, timeout for the gitlab jobs as a whole, which includes slurm queueing time. It then also sets an explicit `SLURM_TIMELIMIT` of one hour (which is what the inferred timelimit is already now on main) for the slurm job itself. For the `setup and pull` job, which as far as I can tell only pulls uenv metadata, I've set a shorter timelimit of 10 minutes, which should hopefully be enough. This should also help the job be backfilled faster by the slurm scheduler.

The exact times are rough proposals and can be adjusted as needed. However, I think it would be important to change the gitlab job timelimit to avoid jobs not running because of longer queueing times.