### PR TITLE
Please do not check /users.OLD on Eiger

### DIFF
--- a/checks/system/integration/eiger.py
+++ b/checks/system/integration/eiger.py
@@ -142,7 +142,7 @@ def create_checks(check):
 
     check.CLASS = 'MOUNTS'
 
-    check('grep -q "/users /users.OLD dvs"                 /proc/mounts || echo FAILED', not_expected=r'FAILED')
+    check('grep -q "/users/cscs /users nfs"                 /proc/mounts || echo FAILED', not_expected=r'FAILED')
     check('grep -q "/capstor/store/cscs /capstor/store/cscs lustre" /proc/mounts || echo FAILED', not_expected=r'FAILED')
 
     check('grep -q "pe_opt_cray_pe /opt/cray/pe"  /proc/mounts || echo FAILED', not_expected=r'FAILED')


### PR DESCRIPTION
Thanks for submitting #301 @ekouts. May I suggest to replace the check of `/users.OLD` with `/users/cscs`? 
As a matter of fact, `/users.OLD` will be removed from the mount points on the system on June 02 2025.