### PR TITLE
Added system configuration for Bristen

### DIFF
--- a/config/systems/bristen.py
+++ b/config/systems/bristen.py
@@ -1,0 +1,101 @@
+# Copyright 2024 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# ReFrame Project Developers. See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# ReFrame CSCS settings
+#
+
+import reframe.utility.osext as osext
+
+
+base_config = {
+    'modules_system': 'nomod',
+    'partitions': [
+        {
+            'name': 'login',
+            'scheduler': 'local',
+            'time_limit': '10m',
+            'environs': [
+                'builtin',
+            ],
+            'descr': 'Login nodes',
+            'max_jobs': 4,
+            'launcher': 'local'
+        },
+        {
+            'name': 'normal',
+            'descr': 'A100',
+            'scheduler': 'slurm',
+            'time_limit': '10m',
+            'container_platforms': [
+            ],
+            'environs': [
+                'builtin',
+            ],
+            'max_jobs': 100,
+            'extras': {
+                'cn_memory': 500,
+            },
+            'features': ['ce', 'gpu', 'nvgpu', 'remote', 'scontrol', 'uenv'],
+            'access': [f'--account=a-{osext.osgroup()}'],
+            'resources': [
+                {
+                    'name': 'switches',
+                    'options': ['--switches={num_switches}']
+                },
+                {
+                    'name': 'gres',
+                    'options': ['--gres={gres}']
+                },
+                {
+                    'name': 'memory',
+                    'options': ['--mem={mem_per_node}']
+                },
+            ],
+            'devices': [
+                {
+                    'type': 'gpu',
+                    'arch': 'sm_80',
+                    'num_devices': 4
+                }
+                ],
+            'launcher': 'srun',
+        },
+    ]
+}
+
+base_config['name'] = 'bristen'
+base_config['descr'] = 'Bristen vcluster'
+base_config['hostnames'] = ['bristen']
+
+site_configuration = {
+    'systems': [
+        base_config,
+    ],
+    'environments': [
+    ],
+    'modes': [
+       {
+           'name': 'cpe_production',
+           'options': [
+               '--max-retries=1',
+               '--report-file=$PWD/latest.json',
+               '-c checks',
+               '--tag=production'
+           ],
+           'target_systems': ['bristen'],
+       },
+       {
+           'name': 'uenv_production',
+           'options': [
+               '--max-retries=1',
+               '--report-file=$PWD/latest.json',
+               '-c checks/apps',
+               '-c checks/libraries',
+               '--tag=production'
+           ],
+           'target_systems': ['bristen'],
+       }
+   ]
+}


### PR DESCRIPTION
I wanted to run some checks on Bristen and I realized this repo does not feature a system config for it, so I put together one by copying the Clariden config (the production system for which Bristen is the development counterpart) and mixing in some bits from Balfrin (as an actively used A100 system with an existing config).

I can successfully carry out a dry-run of the CE checks:
```
[bristen][amadonna@nid001060 container_engine]$ /capstor/scratch/cscs/amadonna/reframe-x86/reframe/bin/reframe -C /capstor/scratch/cscs/amadonna/reframe-tests/config/cscs.py -c /capstor/scratch/cscs/amadonna/reframe-tests/checks/containers/container_engine --mode=production -J account=a-csstaff --system bristen --dry-run
WARNING: redefinition of environment '*:builtin': already defined in '<builtin>'
WARNING: httpjson: could not connect to server httpjson-server:12345: [Errno -2] Name or service not known
WARNING: could not initialize the httpjson handler; ignoring ...
Detecting topology of remote partition 'bristen:normal': this may take some time...
[ReFrame Setup]
  version:           4.7.4
  command:           '/capstor/scratch/cscs/amadonna/reframe-x86/reframe/bin/reframe -C /capstor/scratch/cscs/amadonna/reframe-tests/config/cscs.py -c /capstor/scratch/cscs/amadonna/reframe-tests/checks/containers/container_engine --mode=production -J account=a-csstaff --system bristen --dry-run'
  launched by:       amadonna@nid001060
  working directory: '/capstor/scratch/cscs/amadonna/reframe-tests/checks/containers/container_engine'
  settings files:    '<builtin>', '/capstor/scratch/cscs/amadonna/reframe-tests/config/cscs.py'
  selected system:   'bristen'
  check search path: (R) '/capstor/scratch/cscs/amadonna/reframe-tests/checks/containers/container_engine'
  stage directory:   '/capstor/scratch/cscs/amadonna/regression/production/stage/2025-04-04_13-29-56'
  output directory:  '/capstor/scratch/cscs/amadonna/regression/production/2025-04-04_13-29-56'
  log files:         '/capstor/scratch/cscs/amadonna/reframe-tests/checks/containers/container_engine/reframe.log', '/capstor/scratch/cscs/amadonna/reframe-tests/checks/containers/container_engine/reframe.out'
  results database:  '/users/amadonna/.reframe/reports/results.db'

WARNING: no modules system is set: module 'reframe' will not be unloaded: check the 'modules_system' configuration parameter for your system
[==========] Running 9 check(s)
[==========] Started on Fri Apr  4 13:30:43 2025+0200

[----------] start processing checks
[ DRY      ] CudaNBodyCheckCE /902f2e31 @bristen:normal+builtin
[ DRY      ] OMB_OMPI_CE %test_name=collective/osu_alltoall /b18b4fa1 @bristen:normal+builtin
[ DRY      ] OMB_OMPI_CE %test_name=pt2pt/osu_bw /91e05d9a @bristen:normal+builtin
[ DRY      ] OMB_MPICH_CE %test_name=collective/osu_alltoall /b038565d @bristen:normal+builtin
[ DRY      ] OMB_MPICH_CE %test_name=pt2pt/osu_bw /6b6cce42 @bristen:normal+builtin
[ DRY      ] CUDA_MPS_CE /43bb0e93 @bristen:normal+builtin
[ DRY      ] SSH_CE /2758e626 @bristen:normal+builtin
[ DRY      ] NCCLTestsCE %test_name=sendrecv %image_tag=cuda12.3 /16d65771 @bristen:normal+builtin
[ DRY      ] NCCLTestsCE %test_name=all_reduce %image_tag=cuda12.3 /bc785b73 @bristen:normal+builtin
[       OK ] (1/9) CudaNBodyCheckCE /902f2e31 @bristen:normal+builtin
P: gflops: None Gflop/s (r:28000.0, l:-0.05, u:None)
[       OK ] (2/9) OMB_OMPI_CE %test_name=collective/osu_alltoall /b18b4fa1 @bristen:normal+builtin
P: latency_1M: None us (r:500.0, l:None, u:0.15)
[       OK ] (3/9) OMB_OMPI_CE %test_name=pt2pt/osu_bw /91e05d9a @bristen:normal+builtin
P: bw_4M: None MB/s (r:24000.0, l:-0.15, u:None)
[       OK ] (4/9) OMB_MPICH_CE %test_name=collective/osu_alltoall /b038565d @bristen:normal+builtin
P: latency_1M: None us (r:1800.0, l:None, u:0.15)
[       OK ] (5/9) OMB_MPICH_CE %test_name=pt2pt/osu_bw /6b6cce42 @bristen:normal+builtin
P: bw_4M: None MB/s (r:24000.0, l:-0.15, u:None)
[       OK ] (6/9) CUDA_MPS_CE /43bb0e93 @bristen:normal+builtin
[       OK ] (7/9) SSH_CE /2758e626 @bristen:normal+builtin
[       OK ] (8/9) NCCLTestsCE %test_name=sendrecv %image_tag=cuda12.3 /16d65771 @bristen:normal+builtin
P: GB/s: None GB/s (r:24.0, l:-0.05, u:None)
[       OK ] (9/9) NCCLTestsCE %test_name=all_reduce %image_tag=cuda12.3 /bc785b73 @bristen:normal+builtin
P: GB/s: None GB/s (r:75.0, l:-0.05, u:None)
[----------] all spawned checks have finished

[  PASSED  ] Ran 9/9 test case(s) from 9 check(s) (0 failure(s), 0 skipped, 0 aborted)
[==========] Finished on Fri Apr  4 13:30:45 2025+0200
```

An actual run of the tests resulted in a few failures, but I think that's a separate issue from creating the system config itself.