### PR TITLE
Remove `FI_MR_CACHE_MONITOR=disabled` from cp2k uenv test

### DIFF
--- a/checks/apps/cp2k/cp2k_uenv.py
+++ b/checks/apps/cp2k/cp2k_uenv.py
@@ -175,7 +175,6 @@ class Cp2kCheck_UENV(rfm.RunOnlyRegressionTest):
             self.env_vars["PIKA_THREADS"] = str(self.num_cpus_per_task - 1)
 
         if self.uarch == 'gh200':
-            self.env_vars["FI_MR_CACHE_MONITOR"] = "disabled"
             self.env_vars['MPICH_GPU_SUPPORT_ENABLED'] = '1'
             self.env_vars['CUDA_CACHE_DISABLE'] = '1'
             self.env_vars["DLAF_BT_BAND_TO_TRIDIAG_HH_APPLY_GROUP_SIZE"] = \


### PR DESCRIPTION
Required by DLA-Future eigensolver to avoid hangs, but since only the cholesky decomposition is used from DLA-Future at the moment in the test, and `FI_MR_CACHE_MONITOR=disabled` slows down the overall run, remove it for now.

We're planning to add a new CP2K test which explicitly uses DLA-Future. We'll add back the environment variable specifically for that test once it's needed.