### PR TITLE
Update eiger/pilatus config with newest uenv

### DIFF
--- a/config/systems/eiger.py
+++ b/config/systems/eiger.py
@@ -59,14 +59,6 @@ base_config = {
                 'cpeIntel'
             ],
             'max_jobs': 100,
-
-            #FIXME temporary workaround for uenv=prgenv-gnu_23.11
-            'env_vars': [
-                [
-                    'LD_LIBRARY_PATH',
-                    '$LD_LIBRARY_PATH:/opt/cray/libfabric/1.15.2.0/lib64'
-                ]
-            ],
             'extras': {
                 'cn_memory': 256,
             },

--- a/config/systems/pilatus.py
+++ b/config/systems/pilatus.py
@@ -59,14 +59,6 @@ base_config = {
                 'cpeIntel'
             ],
             'max_jobs': 100,
-
-            #FIXME temporary workaround for uenv=prgenv-gnu_23.11
-            'env_vars': [
-                [
-                    'LD_LIBRARY_PATH',
-                    '$LD_LIBRARY_PATH:/opt/cray/libfabric/1.15.2.0/lib64'
-                ]
-            ],
             'extras': {
                 'cn_memory': 256,
             },


### PR DESCRIPTION
https://github.com/eth-cscs/alps-uenv/blob/main/config.yaml no longer deploys `prgenv-gnu/23`,
the libfabric fix is no longer needed.