### PR TITLE
QE, replace mps wrapper by --gpus-per-task=1

### DIFF
--- a/checks/apps/quantumespresso/quantumespresso_check_uenv.py
+++ b/checks/apps/quantumespresso/quantumespresso_check_uenv.py
@@ -152,6 +152,7 @@ class QeCheckUENV(rfm.RunOnlyRegressionTest):
         if self.uarch == "gh200":
             self.env_vars["MPICH_GPU_SUPPORT_ENABLED"] = "1"
             self.env_vars["OMP_NUM_THREADS"] = str(20)
+            self.env_vars["SLURM_GPUS_PER_TASK"] = 1
 
         # set reference
         if self.uarch is not None and \
@@ -204,7 +205,7 @@ class QeCheckAuSurfUENVExec(QeCheckAuSurfUENV):
         self.executable = f"pw.x"
         uarch = uenv.uarch(self.current_partition)
         if uarch == 'gh200':
-            self.executable = f"./mps-wrapper.sh pw.x"
+            self.executable = f"pw.x"
 
 
 @rfm.simple_test
@@ -227,4 +228,4 @@ class QeCheckAuSurfCustomExecUENV(QeCheckAuSurfUENV):
         self.executable = f"{parent.pwx_executable}"
         uarch = uenv.uarch(self.current_partition)
         if uarch == 'gh200':
-            self.executable = f"./mps-wrapper.sh {parent.pwx_executable}"
+            self.executable = f"{parent.pwx_executable}"


### PR DESCRIPTION
- [ ] Describe the purpose of this pull request (Add a link to the jira issue when possible)
- [ ] Share the command line used to run the test
```console
$ reframe -r ...
```
- You can manually trigger 1 (or more) CI pipelines by adding a `cscs-ci run alps-daint-uenv` comment in the Pull Request
- By default all UENVs will be tested, however you can restrict to a single UENV with: `cscs-ci run alps-daint-uenv;MY_UENV=cp2k/2025.1:v2`

Thank you for taking the time to contribute to `cscs-reframe-tests` !
