### PR TITLE
[NAMD] Adjust references

### DIFF
--- a/checks/apps/namd/namd_check_uenv.py
+++ b/checks/apps/namd/namd_check_uenv.py
@@ -11,8 +11,8 @@ import uenv
 
 namd_references = {
     'stmv': {
-        'gh200': {'ns_day': (93, -0.05, None, 'ns/day')}, 
-        'zen2': {'ns_day': (5.25, -0.05, None, 'ns/day')}
+        'gh200': {'ns_day': (91, -0.05, None, 'ns/day')}, 
+        'zen2': {'ns_day': (4.7, -0.05, None, 'ns/day')}
     },
 }
 


### PR DESCRIPTION
Adjust reference for NAMD for the new Eiger.

For Daint, NAMD seems very stable at 91 so 93 was probably one of the best cases. The tolerance is adjusted to be more in line with the mean and avoid spurious failures.