### PR TITLE
Add rocm benchmark(s)

### DIFF
--- a/checks/containers/container_engine/xccl_tests.py
+++ b/checks/containers/container_engine/xccl_tests.py
@@ -47,6 +47,13 @@ class XCCLTestBase(rfm.RunOnlyRegressionTest, ContainerEngineMixin):
         self.num_tasks = self.num_nodes * self.num_gpus_per_node
 
     @run_after('setup')
+    def set_nchannels_per_net_peer(self):
+        # The following boosts performance for sendrecv in multiple nodes
+        # See https://github.com/NVIDIA/nccl/issues/1272
+        if self.test_name == 'sendrecv':
+            self.env_vars['NCCL_NCHANNELS_PER_NET_PEER'] = 4
+
+    @run_after('setup')
     def set_executable_opts(self):
         self.executable_opts = [
             f'-b {self.min_bytes}', f'-e {self.max_bytes}', f'-g 1'


### PR DESCRIPTION
- [x] example test for @kotsaloscv
- [x] Share the command line used to run the test
```console
UENV=prgenv-gnu/25.07-6.3.3:v3 reframe \
-C cscs-reframe-tests.git/config/cscs.py \
--keep-stage-files --report-file latest.json \
-c cscs-reframe-tests.git/checks/microbenchmarks/gpu/rocm/rocm.py \
--system beverin:mi300 -r
```

- You can manually trigger 1 (or more) CI pipelines by adding a `cscs-ci run alps-daint-uenv` comment in the Pull Request
- By default all UENVs will be tested, however you can restrict to a single UENV with: `cscs-ci run alps-daint-uenv;MY_UENV=cp2k/2025.1:v2`
