### PR TITLE
Merge pipelines

### DIFF
--- a/checks/prgenv/affinity_check.py
+++ b/checks/prgenv/affinity_check.py
@@ -5,7 +5,7 @@
 
 import os
 import pathlib
-import sys 
+import sys
 
 import reframe as rfm
 import reframe.utility.sanity as sn
@@ -21,11 +21,11 @@ class CompileAffinityTool(rfm.CompileOnlyRegressionTest,
     valid_systems = [
         '*'
     ]
-    valid_prog_environs = ['+mpi']
+    valid_prog_environs = ['+mpi +prgenv']
     build_system = 'Make'
     build_locally = False
-    env_vars = {'MPICH_GPU_SUPPORT_ENABLED': 0} 
-    
+    env_vars = {'MPICH_GPU_SUPPORT_ENABLED': 0}
+
     sourcesdir = 'https://github.com/vkarak/affinity'
     tags = {'production', 'scs', 'maintenance', 'craype'}
 
@@ -48,7 +48,7 @@ class CompileAffinityTool(rfm.CompileOnlyRegressionTest,
 
 class CompileAffinityToolNoOmp(CompileAffinityTool):
     valid_systems = ['*']
-    valid_prog_environs = ['+mpi +openmp']
+    valid_prog_environs = ['+mpi +openmp +prgenv']
 
     @run_before('compile')
     def set_build_opts(self):
@@ -73,7 +73,7 @@ class AffinityTestBase(rfm.RunOnlyRegressionTest,
         '+remote'
     ]
     valid_prog_environs = [
-        '+openmp'
+        '+openmp +prgenv'
     ]
 
     tags = {'production', 'scs', 'maintenance', 'craype'}

--- a/checks/prgenv/helloworld.py
+++ b/checks/prgenv/helloworld.py
@@ -105,7 +105,7 @@ class HelloWorldTestSerial(HelloWorldBaseTest):
     num_tasks = 1
     num_tasks_per_node = 1
     num_cpus_per_task = 1
-    valid_prog_environs = ['+serial']
+    valid_prog_environs = ['+serial +prgenv']
 
     @run_after('init')
     def update_description(self):
@@ -121,7 +121,7 @@ class HelloWorldTestOpenMP(HelloWorldBaseTest):
     num_tasks = 1
     num_tasks_per_node = 1
     num_cpus_per_task = 4
-    valid_prog_environs = ['+openmp']
+    valid_prog_environs = ['+openmp +prgenv']
 
     @run_before('compile')
     def set_openmp_flags(self):
@@ -154,7 +154,7 @@ class HelloWorldTestMPI(HelloWorldBaseTest):
     num_tasks = 2
     num_tasks_per_node = 1
     num_cpus_per_task = 1
-    valid_prog_environs = ['+mpi']
+    valid_prog_environs = ['+mpi +prgenv']
 
     @run_after('init')
     def update_description(self):
@@ -171,7 +171,7 @@ class HelloWorldTestMPIOpenMP(HelloWorldBaseTest):
     num_tasks = 6
     num_tasks_per_node = 3
     num_cpus_per_task = 4
-    valid_prog_environs = ['+mpi +openmp']
+    valid_prog_environs = ['+mpi +openmp +prgenv']
 
     @run_after('init')
     def update_description(self):

--- a/checks/prgenv/mpi.py
+++ b/checks/prgenv/mpi.py
@@ -19,7 +19,7 @@ class MpiInitTest(rfm.RegressionTest, ContainerEngineCPEMixin):
     This test checks the value returned by calling MPI_Init_thread.
     '''
     required_threads = ['funneled', 'serialized', 'multiple']
-    valid_prog_environs = ['+mpi']
+    valid_prog_environs = ['+mpi +prgenv']
     valid_systems = ['+remote']
     build_system = 'Make'
     sourcesdir = 'src/mpi_thread'

--- a/checks/system/uenv/uenv_status.py
+++ b/checks/system/uenv/uenv_status.py
@@ -5,7 +5,7 @@ import reframe.utility.sanity as sn
 @rfm.simple_test
 class uenv_status(rfm.RunOnlyRegressionTest):
     valid_systems = ['*']
-    valid_prog_environs = ['*']
+    valid_prog_environs = ['builtin']
     local = True
     executable = 'uenv status'
     tags = {'uenv', 'vs-node-validator'}

--- a/ci/alps_uenv.yml
+++ b/ci/alps_uenv.yml
@@ -71,7 +71,7 @@ reframe:
     - echo "rfm_path=$rfm_path"
     - export PATH=$rfm_path:$PATH
     - reframe -V
-    - ./ci/scripts/alps.sh launch_reframe_1arg "--mode uenv_production"
+    - ./ci/scripts/alps.sh launch_reframe_1arg "--mode daily_production"
   artifacts:
     when: always
     paths:

--- a/ci/alps_uenv.yml
+++ b/ci/alps_uenv.yml
@@ -79,10 +79,10 @@ reframe:
     - |
       if [ -z "${BENCHER_API_TOKEN+x}" ]; then
         # BENCHER_API_TOKEN is UNDEFINED
-        ./ci/scripts/alps.sh launch_reframe_1arg "--mode uenv_production"
+        ./ci/scripts/alps.sh launch_reframe_1arg "--mode daily_production"
       else
         # BENCHER_API_TOKEN is defined (even if empty)
-        ./ci/scripts/alps.sh launch_reframe_bencher "--mode uenv_production"
+        ./ci/scripts/alps.sh launch_reframe_bencher "--mode daily_production"
       fi
   artifacts:
     when: always

--- a/ci/scripts/alps.sh
+++ b/ci/scripts/alps.sh
@@ -13,7 +13,7 @@ if [ $DEBUG = "y" ] ; then
     jfrog=jfrog.svc.cscs.ch/uenv/deploy/$system/$uarch
     jfrog_u="piccinal"
 else
-# {{{ input parameters <--- 
+# {{{ input parameters <---
 # oras="$UENV_PREFIX/libexec/uenv-oras"  # /users/piccinal/.local/ on eiger
 # oras_tmp=`mktemp -d`
 oras_tmp=$PWD
@@ -37,7 +37,7 @@ jfrog_u="piccinal"
  # }}}
 fi
 
-# {{{ setup_jq 
+# {{{ setup_jq
 setup_jq() {
   if [ ! -x /usr/bin/jq ] ;then
     wget --quiet https://github.com/jqlang/jq/releases/download/jq-1.6/jq-linux64
@@ -47,7 +47,7 @@ setup_jq() {
   fi
 }
 # }}}
-# {{{ setup_uenv_and_oras 
+# {{{ setup_uenv_and_oras
 setup_uenv_and_oras() {
   # uenv is installed as a vservice now
   echo
@@ -58,7 +58,7 @@ setup_uenv_and_oras() {
   # rm -f v$uenv_version.tar.gz uenv-$uenv_version)
 }
 # }}}
-# {{{ setup_oras_without_uenv 
+# {{{ setup_oras_without_uenv
 setup_oras_without_uenv() {
   case "$(uname -m)" in
     aarch64)
@@ -79,7 +79,7 @@ setup_oras_without_uenv() {
   ./oras version
 }
 # }}}
-# {{{ check_uenv_oras 
+# {{{ check_uenv_oras
 check_uenv_oras() {
     # [[ -x $UENV_PREFIX ]] || { echo "UENV_PREFIX=$UENV_PREFIX is not set, exiting"; exit 1; }
     # [[ -x $UENV_PREFIX/libexec/uenv-oras ]] || { echo "uenv-oras not found, exiting"; exit 1; }
@@ -87,7 +87,7 @@ check_uenv_oras() {
     [[ -x $oras ]] || { echo "oras=$oras not found, exiting"; exit 1; }
 }
 # }}}
-# {{{ jfrog_login 
+# {{{ jfrog_login
 jfrog_login() {
     creds_json=$(curl --retry 5 --retry-connrefused --fail --silent "$jfrog_request")
     oras_creds="$(echo ${creds_json} | jq --join-output '"--username " + .container_registry.username + " --password " +.container_registry.password')"
@@ -109,7 +109,7 @@ jfrog_login() {
     #  oras discover -v --output json --artifact-type 'uenv/meta' jfrog.svc.cscs.ch/uenv/deploy/santis/gh200/linaro-forge/23.1.2:latest
 }
 # }}}
-# {{{ uenv_image_find 
+# {{{ uenv_image_find
 uenv_image_find() {
     if [ -z $MY_UENV ] ;then
         uenv --no-color image find | tail -n +2 | awk '{print $1}'
@@ -128,8 +128,8 @@ uenv_pull_meta_dir() {
     fi
     uenv image pull --only-meta $vasp_flag $img &> uenv_pull_meta_dir.log
     # TODO: https://github.com/eth-cscs/uenv2/issues/81
-}    
-# }}}    
+}
+# }}}
 # {{{ oras_pull_meta_dir
 oras_pull_meta_dir() {
     img=$1
@@ -151,10 +151,10 @@ meta_has_reframe_yaml() {
     echo "# --- Checking img=$img for meta/extra/reframe.yaml"
     meta_path=`uenv image inspect --format={meta} $img`
     echo "meta_path=$meta_path"
-    rfm_yaml="${meta_path}/extra/reframe.yaml" 
+    rfm_yaml="${meta_path}/extra/reframe.yaml"
     test -f $rfm_yaml ; rc=$?
-    
-    # continue if the uenv has an extra/reframe.yaml file    
+
+    # continue if the uenv has an extra/reframe.yaml file
     if [ $rc -eq 0 ] ;then
         rctools=$(grep -q user-tools $rfm_yaml ; echo $?)
         echo "rc=$rc rctools=$rctools"
@@ -204,7 +204,7 @@ oras_pull_meta_dir_old() {
     $oras pull --output "${oras_tmp}" "$jfrog/$name@$meta_digest" &> oras-pull.log
     rc1=$?
     # echo "rc1=$rc1"
-    rfm_yaml="${oras_tmp}/meta/extra/reframe.yaml" 
+    rfm_yaml="${oras_tmp}/meta/extra/reframe.yaml"
     if [ $rc1 -eq 0 ] ;then
         # find "${oras_tmp}" -name reframe.yaml
         test -f $rfm_yaml
@@ -225,7 +225,7 @@ oras_pull_meta_dir_old() {
     fi
 }
 # }}}
-# {{{ oras_pull_sqfs 
+# {{{ oras_pull_sqfs
 oras_pull_sqfs() {
     name=$1
     tag=$2
@@ -241,9 +241,9 @@ oras_pull_sqfs() {
     #
     squashfs_path="${artifact_path}/store.squashfs"
     echo "$squashfs_path"
-}   
+}
 # }}}
-# {{{ uenv_pull_sqfs 
+# {{{ uenv_pull_sqfs
 uenv_pull_sqfs() {
 # image 1e2d418fe383f793449e61e64c3700de4a07822ee16a89573d78f5e59a781519 is already available locally
 # updating local reference prgenv-gnu/23.11:latest
@@ -260,9 +260,9 @@ uenv_pull_sqfs() {
     squashfs_path=`uenv image inspect $img --format {path}`
     cp $rfm_meta_yaml $squashfs_path/store.yaml
     ls -l $squashfs_path/
-}   
+}
 # }}}
-# {{{ install_reframe 
+# {{{ install_reframe
 install_reframe() {
     # all must be quiet because of last echo
     rm -fr rfm_venv reframe
@@ -271,7 +271,9 @@ install_reframe() {
     # pip install --upgrade reframe-hpc
     # git clone --depth 1 https://github.com/reframe-hpc/reframe.git
     # multi-uenv support only in reframe > v4.5.2:
-    (wget --quiet "https://github.com/reframe-hpc/reframe/archive/refs/heads/develop.zip" && \
+
+    # FIXME: This is temporary until this PR is merged: https://github.com/reframe-hpc/reframe/pull/3516
+    (wget --quiet "https://github.com/ekouts/reframe/archive/refs/heads/feat/sanity_logging.zip" && \
     unzip -qq "develop.zip" && cd reframe-develop && ./bootstrap.sh &> /dev/null)
     export PATH="$(pwd)/reframe-develop/bin:$PATH"
     echo "$(pwd)/reframe-develop/bin"
@@ -283,13 +285,13 @@ install_reframe() {
     # ./bootstrap.sh)
     # echo "$PWD/reframe-4.5.2/bin"
     # export PATH="$(pwd)/reframe/bin:$PATH"
-}    
+}
 # }}}
-# {{{ install_reframe_tests (alps branch) 
+# {{{ install_reframe_tests (alps branch)
 install_reframe_tests() {
     rm -fr cscs-reframe-tests
     git clone -b alps https://github.com/eth-cscs/cscs-reframe-tests.git
-    # TODO: pyfirecrest requires python>=3.7    
+    # TODO: pyfirecrest requires python>=3.7
     # cscs-reframe-tests/config/utilities/requirements.txt
 }
 # }}}
@@ -297,9 +299,9 @@ install_reframe_tests() {
 uenv_sqfs_fullpath() {
     img="$1"
     uenv image inspect $img --format {sqfs}
-}   
+}
 # }}}
-# {{{ launch_reframe_1img 
+# {{{ launch_reframe_1img
 launch_reframe_1img() {
     img=$1
     # export UENV="${squashfs_path}:${mount}"
@@ -314,7 +316,7 @@ launch_reframe_1img() {
     # -n HelloWorldTestMPIOpenMP
 }
 # }}}
-# {{{ launch_reframe 
+# {{{ launch_reframe
 launch_reframe() {
     export RFM_AUTODETECT_METHODS="cat /etc/xthostname,hostname"
     export RFM_USE_LOGIN_SHELL=1
@@ -366,7 +368,7 @@ oneuptime() {
 }
 # }}}
 
-# {{{ main 
+# {{{ main
 in="$1"
 img="$2"
 pe="$3"
@@ -393,4 +395,4 @@ case $in in
     *) echo "unknown arg=$in";;
 esac
 #old [[ -d $oras_tmp ]] && { echo "cleaning $oras_tmp"; rm -fr $oras_tmp; }
-# }}} 
+# }}}

--- a/ci/scripts/prepare_uenvs.sh
+++ b/ci/scripts/prepare_uenvs.sh
@@ -1,0 +1,20 @@
+imgs=$(./ci/scripts/alps.sh uenv_image_find)
+uenv repo status
+for img in $imgs; do
+    # Pull metadata from img
+    echo "uenv_pull_meta_dir for $img!!"
+	./ci/scripts/alps.sh uenv_pull_meta_dir "$img" &> .rc
+	echo "meta_has_reframe_yaml"
+	./ci/scripts/alps.sh meta_has_reframe_yaml "$img" &> .rc
+	cat .rc
+	rc=$(grep -q OK .rc ; echo $?)
+	echo "rc=$rc"
+	if [ $rc -eq 0 ] ; then
+		UENVA+="$img,"
+		echo "UENVA=$UENVA"
+	fi
+done
+UENVA=${UENVA%?}
+UENV=`echo ${UENVA} | sed 's-,,-,-g' | sort -u`
+echo "UENV=$UENV" > rfm_uenv.env
+cat rfm_uenv.env | tr , "\n"

--- a/config/common.py
+++ b/config/common.py
@@ -112,7 +112,7 @@ site_configuration = {
             ]
         },
         {
-           'name': 'cpe_production',
+           'name': 'daily_production',
            'options': [
                '-Sstrict_check=1',
                '--max-retries=1',

--- a/config/cscs.py
+++ b/config/cscs.py
@@ -61,8 +61,8 @@ if site_configuration and uenv_environs:
         ]
         for partition in system['partitions']:
             if partition.get('features', None) and ('uenv' in partition['features']):
-                # Replace the partition environs with the uenv ones
-                partition['environs'] = valid_system_uenv_names
+                # Add the uenvs in the relevant partitions
+                partition['environs'] += valid_system_uenv_names
 
                 # Add the corresponding resources for uenv
                 resources = partition.get('resources', [])

--- a/config/cscs.py
+++ b/config/cscs.py
@@ -24,8 +24,7 @@ def is_var_true(var):
     return var.lower() in ['true', 'yes', '1']
 
 
-firecrest = os.environ.get('RFM_FIRECREST', None)
-systems_path = 'systems-firecrest' if is_var_true(firecrest) else 'systems'
+systems_path = 'systems'
 
 system_conf_files = glob.glob(
     os.path.join(os.path.dirname(__file__), systems_path, '*.py')

--- a/config/cscs.py
+++ b/config/cscs.py
@@ -14,7 +14,6 @@ base_dir = os.path.dirname(os.path.abspath(__file__))
 utilities_path = os.path.join(base_dir, 'utilities')
 sys.path.append(utilities_path)
 
-import firecrest_slurm
 import uenv
 
 

--- a/config/utilities/uenv.py
+++ b/config/utilities/uenv.py
@@ -131,6 +131,8 @@ def _get_uenvs():
             if len(views) > 0:
                 env['resources']['uenv_views'] = {'views': ','.join(views)}
             env['features'] += ['uenv']
+            if env['name'].startswith('prgenv'):
+                env['features'] += ['prgenv']
 
             uenv_environments.append(env)
 

--- a/config/utilities/uenv.py
+++ b/config/utilities/uenv.py
@@ -93,9 +93,10 @@ def _get_uenvs():
                 image_environments = yaml.load(
                     image_envs.read(), Loader=yaml.BaseLoader)
         except OSError as err:
-            raise ConfigError(
-                f"problem loading the metadata from '{rfm_meta}'"
-            )
+            print(f'Skipping uenv `{uenv}`, there was an error '
+                  f'reading the metadata: {err}')
+
+            continue
 
         for k, v in image_environments.items():
             # strip out the fields that are not to be part reframe environment


### PR DESCRIPTION
Merge the UENV and CPE pipelines.

Additional changes in the PR:
- In order to avoid running simple generic tests in almost *every* applications uenv (because some tests just need an `+mpi` feature), we introduce a new feature `prgenv` to differentiate between uenvs that we want to test for simple compilations.
- We use [this branch](https://github.com/ekouts/reframe/tree/feat/sanity_logging) of reframe, until https://github.com/reframe-hpc/reframe/pull/3516 is merged.