### PR TITLE
Update test for ParaView/6.0

### DIFF
--- a/checks/apps/paraview/paraview.py
+++ b/checks/apps/paraview/paraview.py
@@ -31,10 +31,16 @@ class ParaView_coloredSphere(rfm.RunOnlyRegressionTest):
     num_tasks = 12
     num_tasks_per_node = 6
     time_limit = '3m'
-    executable = '/user-environment/ParaView-5.13/bin/pvbatch'
+    executable = './ParaView/bin/pvbatch'
+    # executable = '/user-environment/ParaView-5.13/bin/pvbatch'
     executable_opts = ['-- coloredSphere.py']
     maintainers = ['SSA']
     tags = {'production'}
+
+    @run_before('run')
+    def find_pvbatch(self):
+        self.prerun_cmds = [
+            'ln -fs /user-environment/ParaView-[0-9]* ParaView']
 
     @run_before('run')
     def output_file_info(self):
@@ -71,8 +77,7 @@ class ParaView_catalystClipping(rfm.RegressionTest):
     executable = './bin/dummysph_catalystV2'
     env_vars = {
         'CATALYST_IMPLEMENTATION_NAME': 'paraview',
-        'CATALYST_IMPLEMENTATION_PATHS':
-        '/user-environment/ParaView-5.13/lib64/catalyst',
+        'CATALYST_IMPLEMENTATION_PATHS': '$PWD/ParaView/lib64/catalyst',
         'CATALYST_DATA_DUMP_DIRECTORY': '$PWD/dataset',
     }
     maintainers = ['SSA']
@@ -82,9 +87,9 @@ class ParaView_catalystClipping(rfm.RegressionTest):
     def prepare_build(self):
         tgz = f'v{self.git_tag}.tar.gz'
         self.prebuild_cmds = [
-            f'# tested with paraview/5.13.2:v2 -v paraview-python',
             f'wget -q https://github.com/jfavre/DummySPH/archive/refs/tags/'
             f'{tgz} && tar xf {tgz} && rm -f {tgz}',
+            f'ln -fs /user-environment/ParaView-[0-9]* ParaView',
         ]
         # on eiger, mpicxx/mpicc are broken (g++: No such file)
         self.build_system.cc = 'gcc'


### PR DESCRIPTION
- [x] update test for new uenv: /capstor/scratch/cscs/biddisco/uenvs/paraview-silo-gh200-6.0.0-2025-08-08.squashfs 
- [x] Share the command line used to run the test
```console
UENV=$PWD/JB/paraview-silo-gh200-6.0.0-2025-08-08.squashfs reframe \
 -c cscs-reframe-tests.git/checks/apps/paraview/paraview.py --system daint:normal
```
 
- cscs-ci run alps-daint-uenv;MY_UENV=$PWD/paraview-silo-gh200-6.0.0-2025-08-08.squashfs  (there is no deployed uenv yet)