### PR TITLE
Return perf_value as float

### DIFF
--- a/checks/apps/lammps/lammps.py
+++ b/checks/apps/lammps/lammps.py
@@ -174,7 +174,7 @@ class lammps_gpu_test(rfm.RunOnlyRegressionTest):
         hh = sn.extractsingle(regex, self.stdout, 'hh', int)
         mm = sn.extractsingle(regex, self.stdout, 'mm', int)
         ss = sn.extractsingle(regex, self.stdout, 'ss', int)
-        return (hh*3600 + mm*60 + ss)
+        return float(hh*3600 + mm*60 + ss)
 
 
 @rfm.simple_test
@@ -251,4 +251,4 @@ class lammps_kokkos_test(rfm.RunOnlyRegressionTest):
         hh = sn.extractsingle(regex, self.stdout, 'hh', int)
         mm = sn.extractsingle(regex, self.stdout, 'mm', int)
         ss = sn.extractsingle(regex, self.stdout, 'ss', int)
-        return (hh*3600 + mm*60 + ss)
+        return float(hh*3600 + mm*60 + ss)


### PR DESCRIPTION
- [x] avoid https://confluence.cscs.ch/spaces/reframe/pages/931332823/Integer+values+reported+because+of+truncation
- [x] Share the command line used to run the test
```console
$ UENV=lammps/2024:v1 reframe -r ...
```