### PR TITLE
Fix handling of arguments in `launch_reframe_1arg` CI helper

### DIFF
--- a/ci/scripts/alps.sh
+++ b/ci/scripts/alps.sh
@@ -340,10 +340,10 @@ launch_reframe_1arg() {
     # export RFM_AUTODETECT_XTHOSTNAME=1
     # reframe -V
     echo "# UENV=$UENV"
-    echo "# img=$1"
+    echo "# args=$@"
     reframe -C ./config/cscs.py \
         --report-junit=report.xml \
-        "$@" \
+        $@ \
         --system=$system \
         --prefix=$SCRATCH/rfm-$CI_JOB_ID \
         -r

--- a/ci/scripts/alps.sh
+++ b/ci/scripts/alps.sh
@@ -274,9 +274,9 @@ install_reframe() {
 
     # FIXME: This is temporary until this PR is merged: https://github.com/reframe-hpc/reframe/pull/3516
     (wget --quiet "https://github.com/ekouts/reframe/archive/refs/heads/feat/sanity_logging.zip" && \
-    unzip -qq "develop.zip" && cd reframe-develop && ./bootstrap.sh &> /dev/null)
-    export PATH="$(pwd)/reframe-develop/bin:$PATH"
-    echo "$(pwd)/reframe-develop/bin"
+    unzip -qq "sanity_logging.zip" && cd reframe-feat-sanity_logging && ./bootstrap.sh &> /dev/null)
+    export PATH="$(pwd)/reframe-feat-sanity_logging/bin:$PATH"
+    echo "$(pwd)/reframe-feat-sanity_logging/bin"
     # deps for cscs-reframe-tests.git:
     pip install python-hostlist requests &> .deps.cscs-reframe-tests
     # (wget --quiet "https://github.com/reframe-hpc/reframe/archive/refs/tags/v4.5.2.tar.gz" && \


### PR DESCRIPTION
All pipelines are currently failing to install reframe, e.g. https://gitlab.com/cscs-ci/ci-testing/webhook-ci/mirrors/6557018579987861/835515875116210/-/jobs/11124442179#L37.
```
unzip:  cannot find or open develop.zip, develop.zip.zip or develop.zip.ZIP.
```