### PR TITLE
Don't ignore linalg uenv for testing

### DIFF
--- a/ci/scripts/alps.sh
+++ b/ci/scripts/alps.sh
@@ -113,7 +113,7 @@ jfrog_login() {
 uenv_image_find() {
 # uf |egrep -v "scorep|prgenv|paraview|netcdf-tools|linaro-forge|linalg|jupyterlab|julia|editors" \
 # |grep -v 'size(MB)' |cut -d/ -f1 |sort -u
-    ignore_list="scorep|paraview|netcdf-tools|linaro-forge|linalg|jupyterlab|julia|editors"
+    ignore_list="scorep|paraview|netcdf-tools|linaro-forge|jupyterlab|julia|editors"
     if [ -z $MY_UENV ] ;then
         # -z MY_UENV means 
         # get the list of deployed supported apps (skip header line):


### PR DESCRIPTION
The DLA-Future reframe test requires the linalg uenv to run.

Since it looks like the CI is now only testing the latest uenv, and the `prgenv` feature can be used to filter tests, is there any objection ot removing the ignore list?