### PR TITLE
Make sure `uenv_image_find` in CI scripts uses exact matches on uenv names

### DIFF
--- a/ci/scripts/alps.sh
+++ b/ci/scripts/alps.sh
@@ -120,7 +120,7 @@ uenv_image_find() {
         uenv_apps=$(uenv image find |tail -n +2 |egrep -v "$ignore_list" |cut -d/ -f1 |sort -u)
         for aa in $uenv_apps ;do
             # keep only the most recent uenv (this will break if uenv output changes):
-            uu=$(uenv image find |grep $aa |sort -nk 6 |tail -1 |awk '{print $1}')
+            uu=$(uenv image find $aa |sort -nk 6 |tail -1 |awk '{print $1}')
             echo "$uu"
         done
         # echo "MY_UENV is not set, not sure what uenv to test"


### PR DESCRIPTION
Using the current version on `main` with `grep` would return `linalg-complex` as the "latest" uenv matching `linalg` because both `linalg` and `linalg-complex` match the search term `linalg`.

`uenv image find` accepts a uenv name as a search term and uses that for an exact search, so `uenv image find linalg` will not find `linalg-complex`. This PR removes the grep and uses `uenv image find <image_name>` instead.