### PR TITLE
Customize  HTTPJSON record for Elastic

### DIFF
--- a/config/common.py
+++ b/config/common.py
@@ -6,7 +6,33 @@
 # ReFrame CSCS settings
 #
 
+import json
 import os
+import pprint
+
+
+def _format_httpjson(record, extras, ignore_keys):
+    """
+    https://github.com/eth-cscs/cscs-reframe-tests/pull/380
+    """
+    data = {}
+    for attr, val in record.__dict__.items():
+        if attr in ignore_keys or attr.startswith('_'):
+            continue
+
+        if attr == "check_perf_value" and val:
+            data[attr] = float(val)
+        elif attr == "check_perf_ref" and val:
+            data[attr] = float(val)
+        else:
+            data[attr] = val
+
+    print(data["check_perf_value"])
+    print(data["check_perf_ref"])
+
+    data.update(extras)
+
+    return json.dumps(data)
 
 
 site_configuration = {
@@ -75,6 +101,13 @@ site_configuration = {
                         'rfm_ci_pipeline': os.getenv("CI_PIPELINE_URL", "#"),
                         'rfm_ci_project': os.getenv("CI_PROJECT_PATH", "Unknown CI Project")
                     },
+                    'debug': True,
+                    "json_formatter": _format_httpjson,
+#del                     'format_perfvars': (
+#del                         '%(check_perf_value)s.xx|%(check_perf_unit)s|'
+#del                         #'%(check_perf_ref)s|%(check_perf_lower_thres)s|'
+#del                         #'%(check_perf_upper_thres)s|'
+#del                     ),
                     'ignore_keys': ['check_perfvalues']
                 }
             ]


### PR DESCRIPTION
- [x] Use https://reframe-hpc.readthedocs.io/en/stable/tutorial.html#customizing-the-json-record to cast all integer perf values to float for Elastic (https://github.com/eth-cscs/cscs-reframe-tests/pull/380)
- [x] Share the command line used to run the test
```console
any test that use int as perf. value
```

common.py prints `data["check_perf_value"]`:

```
P: elapsed_min: 7 s (r:0, l:None, u:None)
7.0 <-------- check_perf_value
```

which is what I want (int -> float) BUT 
> jq .runs[0].testcases[0].perfvalues latest.json

will return `7`

and 
> jq . httpjson_record_*.json

will return `  "check_perf_value": 7,`

instead of `7.0`

Same issue with check_perf_ref