### PR TITLE
execute more jobs in parallel on clariden

### DIFF
--- a/config/systems/clariden.py
+++ b/config/systems/clariden.py
@@ -34,7 +34,7 @@ base_config = {
             'environs': [
                 'builtin',
             ],
-            'max_jobs': 100,
+            'max_jobs': 900,
             'extras': {
                 'cn_memory': 825,
             },


### PR DESCRIPTION
- [ ] Increase the number of parallel jobs, to allow vetting of all nodes of clariden in a reasonable time
- [ ] Share the command line used to run the test
```console
$ RFM_IGNORE_REQNODENOTAVAIL=1 ./bin/reframe -C ../cscs-reframe-tests/config/cscs.py   -c ../cscs-reframe-tests/checks/microbenchmarks/cpu_gpu/node_burn/node-burn-ce.py   --prefix=$SCRATCH -S nb_duration=300 -J='--reservation=$RESERVATION' -J='--partition=validation' -J="-w $NODES" --distribute=all -r
```
