### PR TITLE
Add scan and reduce algos from the rocPRIM AMD microbenchmarks

### DIFF
--- a/checks/microbenchmarks/gpu/amd_gpu/amd_gpu.py
+++ b/checks/microbenchmarks/gpu/amd_gpu/amd_gpu.py
@@ -18,7 +18,7 @@ class AmdGPUBenchmarks(rfm.RegressionTest):
     valid_systems = ['+uenv']
     build_system = 'CMake'
     prebuild_cmds = [
-            'git clone --depth 1 -b reframe-ci https://github.com/eth-cscs/amd-gpu-benchmarks.git'
+        'git clone --depth 1 -b reframe-ci https://github.com/eth-cscs/amd-gpu-benchmarks.git'
     ]
     time_limit = '2m'
     build_locally = False


### PR DESCRIPTION
Adding the 2 other algorithms for rocPRIM (exclusive scan and reduce)
https://jira.cscs.ch/browse/SSA-773

Can be run with the following command, tested with v3 (used in CI) and v5:
```
UENV=prgenv-gnu/25.07-6.3.3:v5 reframe -C config/cscs.py  -c checks/microbenchmarks/gpu/amd_gpu/amd_gpu.py --system beverin:mi300 -r
```

Note: this PR introduces a new branch `reframe-ci` on the repo `amd-gpu-benchmarks` to have a stable CI reference. One PR that changes the output was already merged on `main`. So I'm waiting to make the change to the other algorithms to update all the benchmarks together on the `cscs-reframe-tests` repo. 