### PR TITLE
Fix uenv build test with vasp v6.5.1

### DIFF
--- a/checks/apps/vasp/src/makefile.include.gh200
+++ b/checks/apps/vasp/src/makefile.include.gh200
@@ -69,6 +69,9 @@ FFLAGS     += $(VASP_TARGET_CPU)
   
 # Software emulation of quadruple precsion (mandatory)
 QD         ?= $(shell find /user-environment/ -wholename "*compilers/extras/qd" -not -path "*REDIST*" | head -1)
+ifeq ($(strip $(QD)),)
+$(error QD directory not found! Please ensure that the quadruple precision library is installed in /user-environment/)
+endif
 LLIBS      += -L$(QD)/lib -lqdmod -lqd -Wl,-rpath,$(QD)/lib
 INCS       += -I$(QD)/include/qd
   

--- a/checks/apps/vasp/src/makefile.include.gh200
+++ b/checks/apps/vasp/src/makefile.include.gh200
@@ -65,7 +65,7 @@ FFLAGS     += $(VASP_TARGET_CPU)
   
 # Specify your NV HPC-SDK installation (mandatory)
 #... first try to set it automatically
-NVROOT      =$(shell which nvfortran | awk -F /compilers/bin/nvfortran '{ print $$1 }')
+#NVROOT      =$(shell which nvfortran | awk -F /compilers/bin/nvfortran '{ print $$1 }')
   
 # If the above fails, then NVROOT needs to be set manually
 #NVHPC      ?= /opt/nvidia/hpc_sdk
@@ -77,7 +77,7 @@ NVROOT      =$(shell which nvfortran | awk -F /compilers/bin/nvfortran '{ print 
 #SOURCE_IN  := nonlr.o
   
 # Software emulation of quadruple precsion (mandatory)
-QD         ?= $(NVROOT)/compilers/extras/qd
+QD         ?= $(shell find /user-environment/ -wholename "*compilers/extras/qd" -not -path "*REDIST*" | head -1)
 LLIBS      += -L$(QD)/lib -lqdmod -lqd -Wl,-rpath,$(QD)/lib
 INCS       += -I$(QD)/include/qd
   

--- a/checks/apps/vasp/src/makefile.include.gh200
+++ b/checks/apps/vasp/src/makefile.include.gh200
@@ -63,15 +63,6 @@ CXX_PARS    = nvc++ --no_warnings
 VASP_TARGET_CPU ?= -tp host
 FFLAGS     += $(VASP_TARGET_CPU)
   
-# Specify your NV HPC-SDK installation (mandatory)
-#... first try to set it automatically
-#NVROOT      =$(shell which nvfortran | awk -F /compilers/bin/nvfortran '{ print $$1 }')
-  
-# If the above fails, then NVROOT needs to be set manually
-#NVHPC      ?= /opt/nvidia/hpc_sdk
-#NVVERSION   = 21.11
-#NVROOT      = $(NVHPC)/Linux_x86_64/$(NVVERSION)
-  
 ## Improves performance when using NV HPC-SDK >=21.11 and CUDA >11.2
 #OFLAG_IN   = -fast -Mwarperf
 #SOURCE_IN  := nonlr.o

--- a/checks/apps/vasp/vasp_check_uenv.py
+++ b/checks/apps/vasp/vasp_check_uenv.py
@@ -106,7 +106,7 @@ class VaspCheckUENV(rfm.RunOnlyRegressionTest):
 @rfm.simple_test
 class VaspBuildTestUENV(rfm.CompileOnlyRegressionTest):
     '''
-    Test VASP build from source.
+    Test VASP build from source using a modified makefile.
     '''
 
     descr = 'VASP Build Test'


### PR DESCRIPTION
The VASP uenv build test fails for v6.5.1 on daint.
The makefile for VASP needs to be updated to find a NVHPC provided Fortran module.
