### PR TITLE
Update Docker Hub image path for Enroot import test

### DIFF
--- a/checks/system/ce/ce_import_run_image.py
+++ b/checks/system/ce/ce_import_run_image.py
@@ -32,7 +32,7 @@ class enroot_import_image(rfm.RunOnlyRegressionTest):
 
 
 class enroot_import_image_dockerhub(enroot_import_image):
-    image = variable(str, value='docker://index.docker.io#ubuntu:latest')
+    image = variable(str, value='docker://index.docker.io#library/ubuntu:latest')
 
 
 class enroot_import_image_ngc(enroot_import_image):


### PR DESCRIPTION
- [ ] Describe the purpose of this pull request: Testing on Beverin by @rasolca found that the Enroot import test from DockerHub was failing. I have reason to believe that the failure is due to the updates on image reference resolution introduced in Enroot 4.0. With the latest code, DockerHub references should use the `docker.io` shorthand (and let Enroot expand the path) OR provide the full registry path (e.g. `index.docker.io#library/ubuntu:latest`), not a mixed format (e.g. full URL but skipping the namespace: `index.docker.io#ubuntu`). This MR fixes the test by using the full registry path.

