### PR TITLE
Add slurm account name to santis configuration

### DIFF
--- a/config/systems/santis.py
+++ b/config/systems/santis.py
@@ -6,6 +6,8 @@
 # ReFrame CSCS settings
 #
 
+import reframe.utility.osext as osext
+
 site_configuration = {
     'systems': [
         {
@@ -50,6 +52,7 @@ site_configuration = {
                         },
                     ],
                     'features': ['ce', 'gpu', 'nvgpu', 'remote', 'scontrol', 'uenv', 'hugepages_slurm'],
+                    'access': [f'--account=a-{osext.osgroup()}'],
                     'devices': [
                         {
                             'type': 'gpu',

--- a/config/systems/santis.py
+++ b/config/systems/santis.py
@@ -52,7 +52,7 @@ site_configuration = {
                         },
                     ],
                     'features': ['ce', 'gpu', 'nvgpu', 'remote', 'scontrol', 'uenv', 'hugepages_slurm'],
-                    'access': [f'--account=a-{osext.osgroup()}'],
+                    'access': [f'--account={osext.osgroup()}'],
                     'devices': [
                         {
                             'type': 'gpu',


### PR DESCRIPTION
Similarly to https://github.com/eth-cscs/cscs-reframe-tests/pull/551, the account name seems to have been missing for santis.