### PR TITLE
paraview: add gadget plugin build

### DIFF
--- a/checks/apps/paraview/build-gadget-plugin/paraview_buildgadgetplugin.py
+++ b/checks/apps/paraview/build-gadget-plugin/paraview_buildgadgetplugin.py
@@ -47,23 +47,10 @@ class ParaviewBuildGadgetPlugin(rfm.CompileOnlyRegressionTest):
     def prepare_build(self):
         self.prebuild_cmds = [
             'git clone --depth 1 --branch master https://github.com/jfavre/ParaViewGadgetPlugin gadget-plugin.git',
-            dedent(
-                """
-                patch -p 1 -d gadget-plugin.git <<-'EOF'
-                    diff --git a/src/Reader/vtk.module b/src/Reader/vtk.module
-                    index 46b504d..ed640bc 100644
-                    --- a/src/Reader/vtk.module
-                    +++ b/src/Reader/vtk.module
-                    @@ -12,4 +12,4 @@ DEPENDS
-                     PRIVATE_DEPENDS
-                       VTK::vtksys
-                       VTK::mpi
-                    -  VTK::hdf5
-                    +  VTK::hdf5vtk
-                EOF
-                """
-            ),
         ]
+
+        if (fix_actions := need_fix_hdf5vtk(self)) is not None:
+            self.prebuild_cmds.extend(fix_actions)
 
         self.build_system.cc = "gcc"
         self.build_system.cxx = "g++"
@@ -84,3 +71,70 @@ class ParaviewBuildGadgetPlugin(rfm.CompileOnlyRegressionTest):
                 ),
             ]
         )
+
+
+# External VTK and hdf5
+
+
+def has_bug_hdf5vtk(test):
+    """
+    This tells if upstream paraview has the bug of VTK::hdf5 when used as external.
+    """
+    version, _ = test.uenv_version
+
+    if version in SpecifierSet("~=6.1"):
+        return True
+    elif version in SpecifierSet("~=6.0"):
+        return True
+
+    return False
+
+
+def need_fix_hdf5vtk(test):
+    """
+    This tells which fix should be applied according to how bug has been workarounded in uenv.
+    """
+    version, _ = test.uenv_version
+
+    if version in SpecifierSet("~=6.1"):
+        # this is a newer workaround that avoids warning about deprecated targets "vtk*"
+        return [
+            dedent(
+                """
+                patch -p 1 -d gadget-plugin.git <<-'EOF'
+                    diff --git a/src/Reader/vtk.module b/src/Reader/vtk.module
+                    index 46b504d..ed640bc 100644
+                    --- a/src/Reader/vtk.module
+                    +++ b/src/Reader/vtk.module
+                    @@ -12,4 +12,4 @@ DEPENDS
+                     PRIVATE_DEPENDS
+                       VTK::vtksys
+                       VTK::mpi
+                    -  VTK::hdf5
+                    +  VTK::hdf5vtk
+                EOF
+                """
+            )
+        ]
+    elif version in SpecifierSet("~=6.0"):
+        # this is the first workaround applied. it works, but there is a complain about
+        # deprecated targets due to the name chosen, because it starts with "vtk*"
+        return [
+            dedent(
+                """
+                patch -p 1 -d gadget-plugin.git <<-'EOF'
+                    diff --git a/src/Reader/vtk.module b/src/Reader/vtk.module
+                    index 46b504d..ed640bc 100644
+                    --- a/src/Reader/vtk.module
+                    +++ b/src/Reader/vtk.module
+                    @@ -12,4 +12,4 @@ DEPENDS
+                     PRIVATE_DEPENDS
+                       VTK::vtksys
+                       VTK::mpi
+                    -  VTK::hdf5
+                    +  VTK::vtkhdf5
+                EOF
+                """
+            )
+        ]
+    return None

--- a/checks/apps/paraview/build-gadget-plugin/paraview_buildgadgetplugin.py
+++ b/checks/apps/paraview/build-gadget-plugin/paraview_buildgadgetplugin.py
@@ -28,8 +28,8 @@ class ParaviewBuildGadgetPlugin(rfm.CompileOnlyRegressionTest):
             'git clone --depth 1 --branch master https://github.com/jfavre/ParaViewGadgetPlugin gadget-plugin.git',
         ]
 
-        self.build_system.cc = "mpicc"
-        self.build_system.cxx = "mpicxx"
+        self.build_system.cc = "gcc"
+        self.build_system.cxx = "g++"
         self.build_system.builddir = "build"
         self.build_system.configuredir = "gadget-plugin.git"
 

--- a/checks/apps/paraview/build-gadget-plugin/paraview_buildgadgetplugin.py
+++ b/checks/apps/paraview/build-gadget-plugin/paraview_buildgadgetplugin.py
@@ -8,6 +8,19 @@ import reframe.utility.sanity as sn
 
 from textwrap import dedent
 
+from packaging.version import Version
+from packaging.specifiers import SpecifierSet
+
+
+def uenv_metadata():
+    import os
+    import json
+    from reframe.utility import osext
+
+    uenv_label = os.environ['UENV']
+    metadata = json.loads(osext.run_command(f"uenv image inspect --json {uenv_label}").stdout)
+    return Version(metadata["version"]), Version(metadata["tag"])
+
 
 @rfm.simple_test
 class ParaviewBuildGadgetPlugin(rfm.CompileOnlyRegressionTest):
@@ -23,6 +36,12 @@ class ParaviewBuildGadgetPlugin(rfm.CompileOnlyRegressionTest):
 
     maintainers = ['jfavre', 'albestro', 'SSA']
     tags = {'production'}
+
+    uenv_version = variable(tuple, value=(None, None))
+
+    @run_before("compile")
+    def set_version(self):
+        self.uenv_version = uenv_metadata()
 
     @run_before('compile')
     def prepare_build(self):

--- a/checks/apps/paraview/build-gadget-plugin/paraview_buildgadgetplugin.py
+++ b/checks/apps/paraview/build-gadget-plugin/paraview_buildgadgetplugin.py
@@ -1,4 +1,4 @@
-# Copyright 2016 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright ETH Zurich/Swiss National Supercomputing Centre (CSCS)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/apps/paraview/build-gadget-plugin/paraview_buildgadgetplugin.py
+++ b/checks/apps/paraview/build-gadget-plugin/paraview_buildgadgetplugin.py
@@ -1,0 +1,49 @@
+# Copyright 2016 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# ReFrame Project Developers. See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import reframe as rfm
+import reframe.utility.sanity as sn
+
+
+@rfm.simple_test
+class ParaviewBuildGadgetPlugin(rfm.CompileOnlyRegressionTest):
+    valid_systems = ['+uenv']
+    valid_prog_environs = ['+paraview']
+
+    build_system = 'CMake'
+    build_locally = False
+
+    num_tasks = 1
+    num_tasks_per_node = 1
+    time_limit = '3m'
+
+    maintainers = ['jfavre', 'albestro', 'SSA']
+    tags = {'production'}
+
+    @run_before('compile')
+    def prepare_build(self):
+        self.prebuild_cmds = [
+            'git clone --depth 1 --branch master https://github.com/jfavre/ParaViewGadgetPlugin gadget-plugin.git',
+        ]
+
+        self.build_system.cc = "mpicc"
+        self.build_system.cxx = "mpicxx"
+        self.build_system.builddir = "build"
+        self.build_system.configuredir = "gadget-plugin.git"
+
+    @sanity_function
+    def validate_build(self):
+        return sn.all(
+            [
+                sn.assert_eq(
+                    sn.count(sn.glob(r'**/libGadgetReader.so', recursive=True)),
+                    1,
+                ),
+                sn.assert_eq(
+                    sn.count(sn.glob(r'**/pvGadgetReader.so', recursive=True)),
+                    1,
+                ),
+            ]
+        )

--- a/checks/apps/paraview/build-gadget-plugin/paraview_buildgadgetplugin.py
+++ b/checks/apps/paraview/build-gadget-plugin/paraview_buildgadgetplugin.py
@@ -45,8 +45,14 @@ class ParaviewBuildGadgetPlugin(rfm.CompileOnlyRegressionTest):
 
     @run_before('compile')
     def prepare_build(self):
+        commit = "776ad531c2ac559528ff68ba8beabfa3a45c5011"
         self.prebuild_cmds = [
-            'git clone --depth 1 --branch master https://github.com/jfavre/ParaViewGadgetPlugin gadget-plugin.git',
+            "mkdir gadget-plugin.git; pushd gadget-plugin.git",
+            "git init",
+            "git remote add origin https://github.com/jfavre/ParaViewGadgetPlugin",
+            "git fetch --depth 1 origin {}".format(commit),
+            "git reset --hard FETCH_HEAD",
+            "popd",
         ]
 
         if (fix_actions := need_fix_hdf5vtk(self)) is not None:

--- a/checks/apps/paraview/build-gadget-plugin/paraview_buildgadgetplugin.py
+++ b/checks/apps/paraview/build-gadget-plugin/paraview_buildgadgetplugin.py
@@ -6,6 +6,8 @@
 import reframe as rfm
 import reframe.utility.sanity as sn
 
+from textwrap import dedent
+
 
 @rfm.simple_test
 class ParaviewBuildGadgetPlugin(rfm.CompileOnlyRegressionTest):
@@ -26,6 +28,22 @@ class ParaviewBuildGadgetPlugin(rfm.CompileOnlyRegressionTest):
     def prepare_build(self):
         self.prebuild_cmds = [
             'git clone --depth 1 --branch master https://github.com/jfavre/ParaViewGadgetPlugin gadget-plugin.git',
+            dedent(
+                """
+                patch -p 1 -d gadget-plugin.git <<-'EOF'
+                    diff --git a/src/Reader/vtk.module b/src/Reader/vtk.module
+                    index 46b504d..ed640bc 100644
+                    --- a/src/Reader/vtk.module
+                    +++ b/src/Reader/vtk.module
+                    @@ -12,4 +12,4 @@ DEPENDS
+                     PRIVATE_DEPENDS
+                       VTK::vtksys
+                       VTK::mpi
+                    -  VTK::hdf5
+                    +  VTK::hdf5vtk
+                EOF
+                """
+            ),
         ]
 
         self.build_system.cc = "gcc"

--- a/checks/apps/paraview/build-gadget-plugin/paraview_buildgadgetplugin.py
+++ b/checks/apps/paraview/build-gadget-plugin/paraview_buildgadgetplugin.py
@@ -6,7 +6,6 @@
 import reframe as rfm
 import reframe.utility.sanity as sn
 
-from packaging.version import Version
 from packaging.specifiers import SpecifierSet
 from uenv import uenv_metadata
 

--- a/checks/apps/paraview/build-gadget-plugin/paraview_buildgadgetplugin.py
+++ b/checks/apps/paraview/build-gadget-plugin/paraview_buildgadgetplugin.py
@@ -6,32 +6,9 @@
 import reframe as rfm
 import reframe.utility.sanity as sn
 
-from textwrap import dedent
-
 from packaging.version import Version
 from packaging.specifiers import SpecifierSet
-
-
-_UENV_CLI = 'uenv'
-
-
-def uenv_metadata():
-    import os
-    import json
-    from reframe.utility import osext
-
-    uenv_label = os.environ['UENV']
-    _uenv_version = osext.run_command(f'{_UENV_CLI} --version').stdout.strip()
-
-    if Version(_uenv_version) >= Version('9.2.0'):
-        _cmd = f"{_UENV_CLI} image inspect --json {uenv_label}"
-        metadata = json.loads(osext.run_command(_cmd, shell=True).stdout)
-        return Version(metadata["version"]), Version(metadata["tag"])
-    else:
-        _cmd = f"{_UENV_CLI} image inspect --format=\'{{version}} {{tag}}\' {uenv_label}"  # noqa E501
-        _version_tag = osext.run_command(_cmd, shell=True).stdout
-        return str(_version_tag.split(" ")[0]), \
-            str(_version_tag.split(" ")[1])
+from uenv import uenv_metadata
 
 
 @rfm.simple_test

--- a/checks/apps/paraview/build-gadget-plugin/paraview_buildgadgetplugin.py
+++ b/checks/apps/paraview/build-gadget-plugin/paraview_buildgadgetplugin.py
@@ -12,14 +12,26 @@ from packaging.version import Version
 from packaging.specifiers import SpecifierSet
 
 
+_UENV_CLI = 'uenv'
+
+
 def uenv_metadata():
     import os
     import json
     from reframe.utility import osext
 
     uenv_label = os.environ['UENV']
-    metadata = json.loads(osext.run_command(f"uenv image inspect --json {uenv_label}").stdout)
-    return Version(metadata["version"]), Version(metadata["tag"])
+    _uenv_version = osext.run_command(f'{_UENV_CLI} --version').stdout.strip()
+
+    if Version(_uenv_version) >= Version('9.2.0'):
+        _cmd = f"{_UENV_CLI} image inspect --json {uenv_label}"
+        metadata = json.loads(osext.run_command(_cmd, shell=True).stdout)
+        return Version(metadata["version"]), Version(metadata["tag"])
+    else:
+        _cmd = f"{_UENV_CLI} image inspect --format=\'{{version}} {{tag}}\' {uenv_label}"  # noqa E501
+        _version_tag = osext.run_command(_cmd, shell=True).stdout
+        return str(_version_tag.split(" ")[0]), \
+            str(_version_tag.split(" ")[1])
 
 
 @rfm.simple_test
@@ -29,6 +41,9 @@ class ParaviewBuildGadgetPlugin(rfm.CompileOnlyRegressionTest):
 
     build_system = 'CMake'
     build_locally = False
+    repo = variable(str,
+                    value='https://github.com/jfavre/ParaViewGadgetPlugin.git')
+    commit = variable(str, value='d9d12bde19454199b733b4e1285be3dcd1ac5595')
 
     num_tasks = 1
     num_tasks_per_node = 1
@@ -45,14 +60,11 @@ class ParaviewBuildGadgetPlugin(rfm.CompileOnlyRegressionTest):
 
     @run_before('compile')
     def prepare_build(self):
-        commit = "d9d12bde19454199b733b4e1285be3dcd1ac5595"
         self.prebuild_cmds = [
-            "mkdir gadget-plugin.git; pushd gadget-plugin.git",
-            "git init",
-            "git remote add origin https://github.com/jfavre/ParaViewGadgetPlugin",
-            "git fetch --depth 1 origin {}".format(commit),
-            "git reset --hard FETCH_HEAD",
-            "popd",
+            f"mkdir gadget-plugin.git", "cd gadget-plugin.git",
+            f"git init", f"git remote add origin {self.repo}",
+            f"git fetch --depth 1 origin {self.commit}",
+            f"git reset --hard FETCH_HEAD", "cd .."
         ]
 
         if (fix_actions := need_fix_hdf5vtk(self)) is not None:
@@ -62,13 +74,15 @@ class ParaviewBuildGadgetPlugin(rfm.CompileOnlyRegressionTest):
         self.build_system.cxx = "g++"
         self.build_system.builddir = "build"
         self.build_system.configuredir = "gadget-plugin.git"
+        self.env_vars["Python3_ROOT_DIR"] = \
+            '$(dirname $(which python3) |xargs dirname)'
 
     @sanity_function
     def validate_build(self):
         return sn.all(
             [
                 sn.assert_eq(
-                    sn.count(sn.glob(r'**/libGadgetReader.so', recursive=True)),
+                    sn.count(sn.glob(r'**/libGadgetReader.so', recursive=True)),  # noqa: E501
                     1,
                 ),
                 sn.assert_eq(
@@ -79,68 +93,21 @@ class ParaviewBuildGadgetPlugin(rfm.CompileOnlyRegressionTest):
         )
 
 
-# External VTK and hdf5
-
-
-def has_bug_hdf5vtk(test):
-    """
-    This tells if upstream paraview has the bug of VTK::hdf5 when used as external.
-    """
-    version, _ = test.uenv_version
-
-    if version in SpecifierSet("~=6.1"):
-        return True
-    elif version in SpecifierSet("~=6.0"):
-        return True
-
-    return False
-
-
 def need_fix_hdf5vtk(test):
     """
-    This tells which fix should be applied according to how bug has been workarounded in uenv.
+    Patch fix code according to ParaView version
     """
     version, _ = test.uenv_version
 
     if version in SpecifierSet("~=6.1"):
-        # this is a newer workaround that avoids warning about deprecated targets "vtk*"
-        return [
-            dedent(
-                """
-                patch -p 1 -d gadget-plugin.git <<-'EOF'
-                    diff --git a/src/Reader/vtk.module b/src/Reader/vtk.module
-                    index 46b504d..ed640bc 100644
-                    --- a/src/Reader/vtk.module
-                    +++ b/src/Reader/vtk.module
-                    @@ -12,4 +12,4 @@ DEPENDS
-                     PRIVATE_DEPENDS
-                       VTK::vtksys
-                       VTK::mpi
-                    -  VTK::hdf5
-                    +  VTK::hdf5vtk
-                EOF
-                """
-            )
+        _patch_cmd = [
+            'patch -p 1 -d gadget-plugin.git -i ../fix_reader_v61.patch'
         ]
     elif version in SpecifierSet("~=6.0"):
-        # this is the first workaround applied. it works, but there is a complain about
-        # deprecated targets due to the name chosen, because it starts with "vtk*"
-        return [
-            dedent(
-                """
-                patch -p 1 -d gadget-plugin.git <<-'EOF'
-                    diff --git a/src/Reader/vtk.module b/src/Reader/vtk.module
-                    index 46b504d..ed640bc 100644
-                    --- a/src/Reader/vtk.module
-                    +++ b/src/Reader/vtk.module
-                    @@ -12,4 +12,4 @@ DEPENDS
-                     PRIVATE_DEPENDS
-                       VTK::vtksys
-                       VTK::mpi
-                    -  VTK::hdf5
-                    +  VTK::vtkhdf5
-                EOF
-                """
-            )
+        _patch_cmd = [
+            'patch -p 1 -d gadget-plugin.git -i ../fix_reader_v60.patch'
         ]
-    return None
+    else:
+        _patch_cmd = None
+
+    return _patch_cmd

--- a/checks/apps/paraview/build-gadget-plugin/paraview_buildgadgetplugin.py
+++ b/checks/apps/paraview/build-gadget-plugin/paraview_buildgadgetplugin.py
@@ -45,7 +45,7 @@ class ParaviewBuildGadgetPlugin(rfm.CompileOnlyRegressionTest):
 
     @run_before('compile')
     def prepare_build(self):
-        commit = "776ad531c2ac559528ff68ba8beabfa3a45c5011"
+        commit = "d9d12bde19454199b733b4e1285be3dcd1ac5595"
         self.prebuild_cmds = [
             "mkdir gadget-plugin.git; pushd gadget-plugin.git",
             "git init",

--- a/checks/apps/paraview/build-gadget-plugin/src/fix_reader_v60.patch
+++ b/checks/apps/paraview/build-gadget-plugin/src/fix_reader_v60.patch
@@ -1,0 +1,10 @@
+diff --git a/src/Reader/vtk.module b/src/Reader/vtk.module
+index 46b504d..ed640bc 100644
+--- a/src/Reader/vtk.module
++++ b/src/Reader/vtk.module
+@@ -12,4 +12,4 @@ DEPENDS
+ PRIVATE_DEPENDS
+   VTK::vtksys
+   VTK::mpi
+-  VTK::hdf5
++  VTK::vtkhdf5

--- a/checks/apps/paraview/build-gadget-plugin/src/fix_reader_v61.patch
+++ b/checks/apps/paraview/build-gadget-plugin/src/fix_reader_v61.patch
@@ -1,0 +1,10 @@
+diff --git a/src/Reader/vtk.module b/src/Reader/vtk.module
+index 46b504d..ed640bc 100644
+--- a/src/Reader/vtk.module
++++ b/src/Reader/vtk.module
+@@ -12,4 +12,4 @@ DEPENDS
+ PRIVATE_DEPENDS
+   VTK::vtksys
+   VTK::mpi
+-  VTK::hdf5
++  VTK::hdf5vtk

--- a/config/utilities/uenv.py
+++ b/config/utilities/uenv.py
@@ -1,3 +1,4 @@
+import json
 import os
 import pathlib
 import yaml
@@ -46,6 +47,25 @@ def uarch(partition):
     return None
 
 
+def uenv_metadata():
+    # import os
+    # import json
+    # from reframe.utility import osext
+
+    uenv_label = os.environ['UENV']
+    _uenv_version = osext.run_command(f'{_UENV_CLI} --version').stdout.strip()
+
+    if Version(_uenv_version) >= Version('9.2.0'):
+        _cmd = f"{_UENV_CLI} image inspect --json {uenv_label}"
+        metadata = json.loads(osext.run_command(_cmd, shell=True).stdout)
+        return Version(metadata["version"]), Version(metadata["tag"])
+    else:
+        _cmd = f"{_UENV_CLI} image inspect --format=\'{{version}} {{tag}}\' {uenv_label}"  # noqa E501
+        _version_tag = osext.run_command(_cmd, shell=True).stdout
+        return str(_version_tag.split(" ")[0]), \
+            str(_version_tag.split(" ")[1])
+
+
 def _get_uenvs():
     uenv = os.environ.get('UENV', None)
     if uenv is None:
@@ -82,11 +102,13 @@ def _get_uenvs():
             image_path = pathlib.Path(image_path)
             # Check that uenv was pulled
             if not image_path.is_file():
-                raise ConfigError(f"{uenv_name} is missing, "
+                raise ConfigError(
+                    f"{uenv_name} is missing, "
                     f"try pulling it with: uenv image pull {uenv_name}")
             try:
                 if image_path.stat().st_size == 0:
-                    raise ConfigError(f"{uenv_name} is empty, "
+                    raise ConfigError(
+                        f"{uenv_name} is empty, "
                         f"try pulling it with: uenv image pull {uenv_name}")
             except FileNotFoundError:
                 raise ConfigError(f"{uenv_name} was not found")
@@ -132,13 +154,15 @@ def _get_uenvs():
                 )
 
             # Replace characters that create problems in environment names
-            uenv_name_pretty = uenv_name.replace(":", "_").replace("/", "_").replace("%", "_")
+            uenv_name_pretty = \
+                uenv_name.replace(":", "_").replace("/", "_").replace("%", "_")
             env['name'] = f'{uenv_name_pretty}_{k}'
             env['resources'] = {
                 'uenv': {
                     'file': str(image_path),
                     'mount': image_mount,
-                    'uenv': f'{image_path}:{image_mount}' if image_mount else str(image_path)
+                    'uenv': f'{image_path}:{image_mount}' if image_mount
+                            else str(image_path)
                 }
             }
             if len(views) > 0:


### PR DESCRIPTION
This new test compiles a paraview plugin, namely [ParaViewGadgetPlugin](https://github.com/jfavre/ParaViewGadgetPlugin/) by @jfavre, using it as a kind-of canary test for major problems with the uenv image. It also verifies that libraries have been actually built.

This test targets `paraview` uenvs starting from `paraview@6` onward.

```console
UENV=paraview/6.1:v1-rc3 reframe -C config/cscs.py -c checks/apps/paraview --system daint -r -n ParaviewBuildGadgetPlugin
```

Note: currently the build should fail because of a workaround in-place in the uenv image. I'm going to use it as verification that the test fails and then I will add a patch to the test to comply with the workaround (and I'll remove it as soon as it will dropped in a future uenv release).