### PR TITLE
Update MemoryOverconsumption checks for oneapi compiler

### DIFF
--- a/checks/system/slurm/slurm.py
+++ b/checks/system/slurm/slurm.py
@@ -186,6 +186,11 @@ class MemoryOverconsumptionCheck(SlurmCompiledBaseCheck):
     sourcepath = 'eatmem/eatmemory.c'
     executable_opts = ['4000M']
 
+    @run_before('compile')
+    def oneapi_compilers(self):
+        if 'oneapi' in self.current_environ.features:
+            self.build_system.cflags += ['-g']
+
     @run_before('run')
     def set_memory_limit(self):
         self.job.options = ['--mem=2000']

--- a/checks/system/slurm/slurm.py
+++ b/checks/system/slurm/slurm.py
@@ -209,6 +209,12 @@ class MemoryOverconsumptionCheckMPI(SlurmCompiledBaseCheck,
     # env_vars = {'MPICH_GPU_SUPPORT_ENABLED': 0}
     tags.add('mem')
 
+    @run_before('compile')
+    def oneapi_compilers(self):
+        print(f"xx={self.current_environ.features}")
+        if 'oneapi' in self.current_environ.features:
+            self.build_system.cflags += ['-g']
+
     @run_before('run')
     def set_num_tasks(self):
         self.skip_if_no_procinfo()

--- a/checks/system/slurm/slurm.py
+++ b/checks/system/slurm/slurm.py
@@ -211,7 +211,6 @@ class MemoryOverconsumptionCheckMPI(SlurmCompiledBaseCheck,
 
     @run_before('compile')
     def oneapi_compilers(self):
-        print(f"xx={self.current_environ.features}")
         if 'oneapi' in self.current_environ.features:
             self.build_system.cflags += ['-g']
 


### PR DESCRIPTION
- [x] intel compiler require extra flag to have a working test.
- [x] Run on eiger with:
```console
$ UENV=prgenv-intel/2022.1:xxx reframe -c ./checks/system/slurm/slurm.py -n MemoryOverconsumptionCheckMPI -r
```