### PR TITLE
QE update reference time

### DIFF
--- a/checks/apps/quantumespresso/quantumespresso_check_uenv.py
+++ b/checks/apps/quantumespresso/quantumespresso_check_uenv.py
@@ -13,7 +13,7 @@ import uenv
 
 qe_references = {
     "Au surf": {
-        "gh200": {"time_run": (14.02, None, 0.05, "s")},
+        "gh200": {"time_run": (8.74, None, 0.05, "s")},
         "zen2": {"time_run": (99.45, None, 0.1, "s")},  # 1m44s
     },
 }


### PR DESCRIPTION
QE experienced a ~30% speedup after the system update.

```
|    QE | Run                   | Slingshot | NV Driver | electrons | fftw   | vloc_psi | h_psi  | sum_band |
|-------+-----------------------+-----------+-----------+-----------+--------+----------+--------+----------|
|   7.5 | uss140-shs131-nv590   |     1.3.1 |       590 | 8.49 s    | 2.45 s | 1.61 s   | 2.08 s | 1.99 s   |
|   7.5 | uss131-shs1201-nv565  |    12.0.1 |       565 | 9.45 s    | 3.35 s | 2.31 s   | 2.83 s | 2.31 s   |
|   7.5 | uss110-shs111-nv550   |     1.1.1 |       550 | 13.43 s   | 5.74 s | 4.20 s   | 4.80 s | 4.23 s   |
|   7.5 | current daint         |           |           | 8.74 s    | 2.41 s | 1.65 s   | 2.25 s | 2.14 s   |
| 7.4.1 | reference (GH200 old) |           |           | 14.02 s   |        |          |        |          |
```

It looks like the main cause is faster fft (afaik this is cufft, not fftw as the timer label suggests)