### PR TITLE
Don't use walrus operator for system python 3.6 support

### DIFF
--- a/checks/apps/paraview/build-gadget-plugin/paraview_buildgadgetplugin.py
+++ b/checks/apps/paraview/build-gadget-plugin/paraview_buildgadgetplugin.py
@@ -43,7 +43,8 @@ class ParaviewBuildGadgetPlugin(rfm.CompileOnlyRegressionTest):
             f"git reset --hard FETCH_HEAD", "cd .."
         ]
 
-        if (fix_actions := need_fix_hdf5vtk(self)) is not None:
+        fix_actions = need_fix_hdf5vtk(self)
+        if fix_actions is not None:
             self.prebuild_cmds.extend(fix_actions)
 
         self.build_system.cc = "gcc"


### PR DESCRIPTION
Don't use walrus operator (introduced in python 3.8) as a quick fix for failing uenv CI pipelines.

Yesterday uenv CI pipelines started failing because they use the system python which is still a very old 3.6. See https://gitlab.com/cscs-ci/ci-testing/webhook-ci/mirrors/7846031063687376/755017428418954/-/jobs/14328690974#L172.

I think it would probably be good to officially state the oldest python version supported and probably bump CI pipelines to use a newer python, but to get things working again I've simply removed the use of the walrus operator. The use was introduced yesterday in #559.

FYI @jgphpc @albestro.