### PR TITLE
Normalize copyright headers

### DIFF
--- a/checks/apps/arbor/arbor-dev.py
+++ b/checks/apps/arbor/arbor-dev.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/apps/arbor/arbor-dev.py
+++ b/checks/apps/arbor/arbor-dev.py
@@ -6,7 +6,6 @@
 import os
 import reframe as rfm
 import reframe.utility.sanity as sn
-import reframe.utility.udeps as udeps
 import uenv
 
 arbor_references = {

--- a/checks/apps/greasy/greasy_check.py
+++ b/checks/apps/greasy/greasy_check.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/apps/icon/rrtmgp_check.py
+++ b/checks/apps/icon/rrtmgp_check.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/apps/jupyter/check_ipcmagic.py
+++ b/checks/apps/jupyter/check_ipcmagic.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/apps/namd/namd_check_uenv.py
+++ b/checks/apps/namd/namd_check_uenv.py
@@ -1,3 +1,4 @@
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/apps/paraview/build-gadget-plugin/paraview_buildgadgetplugin.py
+++ b/checks/apps/paraview/build-gadget-plugin/paraview_buildgadgetplugin.py
@@ -1,4 +1,4 @@
-# Copyright ETH Zurich/Swiss National Supercomputing Centre (CSCS)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/apps/paraview/catalystclipping/paraview_catalystclipping.py
+++ b/checks/apps/paraview/catalystclipping/paraview_catalystclipping.py
@@ -1,4 +1,4 @@
-# Copyright ETH Zurich/Swiss National Supercomputing Centre (CSCS)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/apps/paraview/coloredsphere/paraview_coloredsphere.py
+++ b/checks/apps/paraview/coloredsphere/paraview_coloredsphere.py
@@ -1,4 +1,4 @@
-# Copyright ETH Zurich/Swiss National Supercomputing Centre (CSCS)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/apps/paraview/paraview.py
+++ b/checks/apps/paraview/paraview.py
@@ -1,4 +1,4 @@
-# Copyright 2016 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/apps/python/numpy_check.py
+++ b/checks/apps/python/numpy_check.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/apps/pytorch/mlperf_storage_ce.py
+++ b/checks/apps/pytorch/mlperf_storage_ce.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/apps/pytorch/mlperf_storage_sarus.py
+++ b/checks/apps/pytorch/mlperf_storage_sarus.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import os
-import sys
 
 import reframe as rfm
 import reframe.utility.sanity as sn

--- a/checks/apps/pytorch/mlperf_storage_sarus.py
+++ b/checks/apps/pytorch/mlperf_storage_sarus.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/apps/pytorch/pytorch_allreduce.py
+++ b/checks/apps/pytorch/pytorch_allreduce.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/apps/pytorch/pytorch_horovod_check.py
+++ b/checks/apps/pytorch/pytorch_horovod_check.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/apps/pytorch/pytorch_megatronlm.py
+++ b/checks/apps/pytorch/pytorch_megatronlm.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/apps/pytorch/pytorch_megatronlm_amd.py
+++ b/checks/apps/pytorch/pytorch_megatronlm_amd.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/apps/pytorch/pytorch_megatronlm_amd_optimized.py
+++ b/checks/apps/pytorch/pytorch_megatronlm_amd_optimized.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/apps/quantumespresso/quantumespresso_check_uenv.py
+++ b/checks/apps/quantumespresso/quantumespresso_check_uenv.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2024 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/apps/spark/spark_check.py
+++ b/checks/apps/spark/spark_check.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/apps/tensorflow/tf2_horovod_check.py
+++ b/checks/apps/tensorflow/tf2_horovod_check.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/apps/vasp/vasp_check_uenv.py
+++ b/checks/apps/vasp/vasp_check_uenv.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2024 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/containers/container_engine/check_cuda_nbody.py
+++ b/checks/containers/container_engine/check_cuda_nbody.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/containers/container_engine/cuda_mps.py
+++ b/checks/containers/container_engine/cuda_mps.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/containers/container_engine/omb.py
+++ b/checks/containers/container_engine/omb.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/containers/container_engine/ssh.py
+++ b/checks/containers/container_engine/ssh.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/containers/sarus/check_cuda_nbody.py
+++ b/checks/containers/sarus/check_cuda_nbody.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/containers/sarus/check_gpu_ids.py
+++ b/checks/containers/sarus/check_gpu_ids.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/containers/sarus/check_osu_benchmarks.py
+++ b/checks/containers/sarus/check_osu_benchmarks.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/containers/sarus/check_osu_benchmarks_cuda.py
+++ b/checks/containers/sarus/check_osu_benchmarks_cuda.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/containers/sarus/check_pull_command.py
+++ b/checks/containers/sarus/check_pull_command.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/containers/sarus/check_pyfr.py
+++ b/checks/containers/sarus/check_pyfr.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/containers/sarus/check_root_squash_bind_mount.py
+++ b/checks/containers/sarus/check_root_squash_bind_mount.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/libraries/boost/boost_python_check.py
+++ b/checks/libraries/boost/boost_python_check.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/libraries/cray-libsci/libsci_acc.py
+++ b/checks/libraries/cray-libsci/libsci_acc.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/libraries/gridtools/gridtools_tests.py
+++ b/checks/libraries/gridtools/gridtools_tests.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/libraries/io/h5py_mpi.py
+++ b/checks/libraries/io/h5py_mpi.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/libraries/io/hdf5_compile_run.py
+++ b/checks/libraries/io/hdf5_compile_run.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/libraries/io/netcdf.py
+++ b/checks/libraries/io/netcdf.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/libraries/io/netcdf_compile_run.py
+++ b/checks/libraries/io/netcdf_compile_run.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/libraries/io/pnetcdf.py
+++ b/checks/libraries/io/pnetcdf.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/libraries/magma/magma_checks.py
+++ b/checks/libraries/magma/magma_checks.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/libraries/math/scalapack_compile_run.py
+++ b/checks/libraries/math/scalapack_compile_run.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/libraries/math/trilinos_compile_run.py
+++ b/checks/libraries/math/trilinos_compile_run.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/libraries/opengl/opengl_checks.py
+++ b/checks/libraries/opengl/opengl_checks.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/libraries/petsc/petsc_helloworld.py
+++ b/checks/libraries/petsc/petsc_helloworld.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/microbenchmarks/cpu/alloc_speed/alloc_speed.py
+++ b/checks/microbenchmarks/cpu/alloc_speed/alloc_speed.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/microbenchmarks/cpu/dgemm/dgemm.py
+++ b/checks/microbenchmarks/cpu/dgemm/dgemm.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/microbenchmarks/cpu/fft/fftw_benchmark.py
+++ b/checks/microbenchmarks/cpu/fft/fftw_benchmark.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/microbenchmarks/cpu/latency/latency.py
+++ b/checks/microbenchmarks/cpu/latency/latency.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/microbenchmarks/cpu/likwid/check_cpu_bandwith.py
+++ b/checks/microbenchmarks/cpu/likwid/check_cpu_bandwith.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/microbenchmarks/cpu/roofline/berkeley-ert.py
+++ b/checks/microbenchmarks/cpu/roofline/berkeley-ert.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/microbenchmarks/cpu/simd/nsimd.py
+++ b/checks/microbenchmarks/cpu/simd/nsimd.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/microbenchmarks/cpu/stream/stream.py
+++ b/checks/microbenchmarks/cpu/stream/stream.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2024 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/microbenchmarks/cpu/strided_bandwidth/strides.py
+++ b/checks/microbenchmarks/cpu/strided_bandwidth/strides.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/microbenchmarks/cpu_gpu/node_burn/node-burn-ce.py
+++ b/checks/microbenchmarks/cpu_gpu/node_burn/node-burn-ce.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/microbenchmarks/gpu/dgemm/dgemm.py
+++ b/checks/microbenchmarks/gpu/dgemm/dgemm.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2020 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/microbenchmarks/gpu/gpu_burn/gpu_burn_test.py
+++ b/checks/microbenchmarks/gpu/gpu_burn/gpu_burn_test.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/microbenchmarks/gpu/hooks.py
+++ b/checks/microbenchmarks/gpu/hooks.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/microbenchmarks/gpu/kernel_latency/kernel_latency.py
+++ b/checks/microbenchmarks/gpu/kernel_latency/kernel_latency.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/microbenchmarks/gpu/memory_bandwidth/memory_bandwidth.py
+++ b/checks/microbenchmarks/gpu/memory_bandwidth/memory_bandwidth.py
@@ -1,4 +1,4 @@
-# Copyright 2016 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/microbenchmarks/gpu/node_burn/baremetal-node-burn.py
+++ b/checks/microbenchmarks/gpu/node_burn/baremetal-node-burn.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/microbenchmarks/gpu/pointer_chase/pointer_chase.py
+++ b/checks/microbenchmarks/gpu/pointer_chase/pointer_chase.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2020 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/microbenchmarks/gpu/roofline/berkeley-ert-gpu.py
+++ b/checks/microbenchmarks/gpu/roofline/berkeley-ert-gpu.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/microbenchmarks/gpu/shmem/shmem.py
+++ b/checks/microbenchmarks/gpu/shmem/shmem.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/microbenchmarks/hpcg/hpcg_benchmark.py
+++ b/checks/microbenchmarks/hpcg/hpcg_benchmark.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/microbenchmarks/hpl/hpl_check.py
+++ b/checks/microbenchmarks/hpl/hpl_check.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/microbenchmarks/mpi/halo_exchange/halo_cell_exchange.py
+++ b/checks/microbenchmarks/mpi/halo_exchange/halo_cell_exchange.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/microbenchmarks/mpi/osu/osu_run.py
+++ b/checks/microbenchmarks/mpi/osu/osu_run.py
@@ -1,4 +1,4 @@
-# Copyright 2016 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/microbenchmarks/mpi/osu/osu_tests.py
+++ b/checks/microbenchmarks/mpi/osu/osu_tests.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/microbenchmarks/xccl/xccl_tests.py
+++ b/checks/microbenchmarks/xccl/xccl_tests.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/mixins/container_engine.py
+++ b/checks/mixins/container_engine.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/mixins/cuda_visible_devices_all.py
+++ b/checks/mixins/cuda_visible_devices_all.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/mixins/extra_launcher_options.py
+++ b/checks/mixins/extra_launcher_options.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/mixins/sarus_extra_launcher_options.py
+++ b/checks/mixins/sarus_extra_launcher_options.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/mixins/slurm_mpi_pmix.py
+++ b/checks/mixins/slurm_mpi_pmix.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/mixins/uenv_setup.py
+++ b/checks/mixins/uenv_setup.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/mixins/uenv_slurm_mpi_options.py
+++ b/checks/mixins/uenv_slurm_mpi_options.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/prgenv/affinity_check.py
+++ b/checks/prgenv/affinity_check.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/prgenv/cpu_target_check.py
+++ b/checks/prgenv/cpu_target_check.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/prgenv/cuda/cuda_aware_mpi.py
+++ b/checks/prgenv/cuda/cuda_aware_mpi.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/prgenv/cuda/cuda_memtest_check.py
+++ b/checks/prgenv/cuda/cuda_memtest_check.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/prgenv/cuda/cuda_mpi_intranode_pinned.py
+++ b/checks/prgenv/cuda/cuda_mpi_intranode_pinned.py
@@ -1,5 +1,5 @@
-# Copyright ETHZ/CSCS
-# See the top-level LICENSE file for details.
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 

--- a/checks/prgenv/cuda/cuda_nvml.py
+++ b/checks/prgenv/cuda/cuda_nvml.py
@@ -1,4 +1,4 @@
-# Copyright 2016 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/prgenv/cuda/cuda_samples.py
+++ b/checks/prgenv/cuda/cuda_samples.py
@@ -1,4 +1,4 @@
-# Copyright 2016 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/prgenv/cuda_fortran.py
+++ b/checks/prgenv/cuda_fortran.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/prgenv/environ_check.py
+++ b/checks/prgenv/environ_check.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/prgenv/environ_check.py
+++ b/checks/prgenv/environ_check.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import reframe as rfm
-import reframe.utility.osext as osext
+# import reframe.utility.osext as osext
 import reframe.utility.sanity as sn
 
 

--- a/checks/prgenv/helloworld.py
+++ b/checks/prgenv/helloworld.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/prgenv/mpi.py
+++ b/checks/prgenv/mpi.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2024 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/prgenv/openacc.py
+++ b/checks/prgenv/openacc.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/prgenv/opencl.py
+++ b/checks/prgenv/opencl.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/prgenv/prgenv_check.py
+++ b/checks/prgenv/prgenv_check.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/prgenv/ssh_environ_check.py
+++ b/checks/prgenv/ssh_environ_check.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/prgenv/ulimit_check.py
+++ b/checks/prgenv/ulimit_check.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/system/ce/ce_import_run_image.py
+++ b/checks/system/ce/ce_import_run_image.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/system/integration/alps.py
+++ b/checks/system/integration/alps.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/system/integration/constants.py
+++ b/checks/system/integration/constants.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/system/integration/utils.py
+++ b/checks/system/integration/utils.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/system/io/dd_blk_size.py
+++ b/checks/system/io/dd_blk_size.py
@@ -1,5 +1,5 @@
-# Copyright 2026 ETHZ/CSCS
-# See the top-level LICENSE file for details.
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 

--- a/checks/system/io/fio.py
+++ b/checks/system/io/fio.py
@@ -1,5 +1,5 @@
-# Copyright 2026 ETHZ/CSCS
-# See the top-level LICENSE file for details.
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 

--- a/checks/system/io/ior_check.py
+++ b/checks/system/io/ior_check.py
@@ -1,4 +1,4 @@
-# Copyright 2016 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/system/jobreport/gpu_report.py
+++ b/checks/system/jobreport/gpu_report.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/system/network/cxi_gpu_loopback_bw.py
+++ b/checks/system/network/cxi_gpu_loopback_bw.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/system/network/cxi_stat_hsn.py
+++ b/checks/system/network/cxi_stat_hsn.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/system/nvidia/nvidia_device_count.py
+++ b/checks/system/nvidia/nvidia_device_count.py
@@ -1,4 +1,4 @@
-# Copyright 2016 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/system/nvidia/nvidia_smi_check.py
+++ b/checks/system/nvidia/nvidia_smi_check.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/system/openstack/s3_check.py
+++ b/checks/system/openstack/s3_check.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/system/slurm/cscs_usertools.py
+++ b/checks/system/slurm/cscs_usertools.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/system/slurm/hetjob.py
+++ b/checks/system/slurm/hetjob.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/system/slurm/invalid_acc.py
+++ b/checks/system/slurm/invalid_acc.py
@@ -1,5 +1,5 @@
-# Copyright ETHZ/CSCS
-# See the top-level LICENSE file for details.
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 

--- a/checks/system/systems_data/extract_data.py
+++ b/checks/system/systems_data/extract_data.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/tools/io/cdo.py
+++ b/checks/tools/io/cdo.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/tools/io/cdo_legacy.py
+++ b/checks/tools/io/cdo_legacy.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/tools/io/nco.py
+++ b/checks/tools/io/nco.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/tools/io/nco_legacy.py
+++ b/checks/tools/io/nco_legacy.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/tools/jupyter/jupyter_tests.py
+++ b/checks/tools/jupyter/jupyter_tests.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/tools/profiling_and_debugging/cuda_gdb.py
+++ b/checks/tools/profiling_and_debugging/cuda_gdb.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/tools/profiling_and_debugging/notool.py
+++ b/checks/tools/profiling_and_debugging/notool.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/checks/tools/profiling_and_debugging/nvprof.py
+++ b/checks/tools/profiling_and_debugging/nvprof.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause


### PR DESCRIPTION
Use same header for all checks:
```
# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
# ReFrame Project Developers. See the top-level LICENSE file for details.
#
# SPDX-License-Identifier: BSD-3-Clause
```