### PR TITLE
uenv: expose uenv `version` and `tag` as current_environ.extras["version"] + allow SQFS|LABEL format in UENV env variable

### DIFF
--- a/checks/apps/paraview/build-gadget-plugin/paraview_buildgadgetplugin.py
+++ b/checks/apps/paraview/build-gadget-plugin/paraview_buildgadgetplugin.py
@@ -7,7 +7,6 @@ import reframe as rfm
 import reframe.utility.sanity as sn
 
 from packaging.specifiers import SpecifierSet
-from uenv import uenv_metadata
 
 
 @rfm.simple_test
@@ -32,7 +31,7 @@ class ParaviewBuildGadgetPlugin(rfm.CompileOnlyRegressionTest):
 
     @run_before("compile")
     def set_version(self):
-        self.uenv_version = uenv_metadata()
+        self.uenv_version = self.current_environ.extras["version"]
 
     @run_before('compile')
     def prepare_build(self):
@@ -76,14 +75,10 @@ def need_fix_hdf5vtk(test):
     """
     version, _ = test.uenv_version
 
-    if version in SpecifierSet("~=6.1"):
-        _patch_cmd = [
-            'patch -p 1 -d gadget-plugin.git -i ../fix_reader_v61.patch'
-        ]
+    if version is None or version in SpecifierSet("~=6.1"):
+        _patch_cmd = ['patch -p 1 -d gadget-plugin.git -i ../fix_reader_v61.patch']
     elif version in SpecifierSet("~=6.0"):
-        _patch_cmd = [
-            'patch -p 1 -d gadget-plugin.git -i ../fix_reader_v60.patch'
-        ]
+        _patch_cmd = ['patch -p 1 -d gadget-plugin.git -i ../fix_reader_v60.patch']
     else:
         _patch_cmd = None
 

--- a/checks/apps/paraview/build-gadget-plugin/paraview_buildgadgetplugin.py
+++ b/checks/apps/paraview/build-gadget-plugin/paraview_buildgadgetplugin.py
@@ -29,28 +29,28 @@ class ParaviewBuildGadgetPlugin(rfm.CompileOnlyRegressionTest):
 
     uenv_version = variable(tuple, value=(None, None))
 
-    @run_before("compile")
+    @run_before('compile')
     def set_version(self):
-        self.uenv_version = self.current_environ.extras["version"]
+        self.uenv_version = self.current_environ.extras['version']
 
     @run_before('compile')
     def prepare_build(self):
         self.prebuild_cmds = [
-            f"mkdir gadget-plugin.git", "cd gadget-plugin.git",
-            f"git init", f"git remote add origin {self.repo}",
-            f"git fetch --depth 1 origin {self.commit}",
-            f"git reset --hard FETCH_HEAD", "cd .."
+            f'mkdir gadget-plugin.git', 'cd gadget-plugin.git',
+            f'git init', f'git remote add origin {self.repo}',
+            f'git fetch --depth 1 origin {self.commit}',
+            f'git reset --hard FETCH_HEAD', 'cd ..'
         ]
 
         fix_actions = need_fix_hdf5vtk(self)
         if fix_actions is not None:
             self.prebuild_cmds.extend(fix_actions)
 
-        self.build_system.cc = "gcc"
-        self.build_system.cxx = "g++"
-        self.build_system.builddir = "build"
-        self.build_system.configuredir = "gadget-plugin.git"
-        self.env_vars["Python3_ROOT_DIR"] = \
+        self.build_system.cc = 'gcc'
+        self.build_system.cxx = 'g++'
+        self.build_system.builddir = 'build'
+        self.build_system.configuredir = 'gadget-plugin.git'
+        self.env_vars['Python3_ROOT_DIR'] = \
             '$(dirname $(which python3) |xargs dirname)'
 
     @sanity_function
@@ -70,15 +70,15 @@ class ParaviewBuildGadgetPlugin(rfm.CompileOnlyRegressionTest):
 
 
 def need_fix_hdf5vtk(test):
-    """
-    Patch fix code according to ParaView version
-    """
+    """Patch code according to ParaView version"""
     version, _ = test.uenv_version
 
-    if version is None or version in SpecifierSet("~=6.1"):
-        _patch_cmd = ['patch -p 1 -d gadget-plugin.git -i ../fix_reader_v61.patch']
-    elif version in SpecifierSet("~=6.0"):
-        _patch_cmd = ['patch -p 1 -d gadget-plugin.git -i ../fix_reader_v60.patch']
+    if version is None or version in SpecifierSet('~=6.1'):
+        _patch_cmd = [
+            'patch -p 1 -d gadget-plugin.git -i ../fix_reader_v61.patch']
+    elif version in SpecifierSet('~=6.0'):
+        _patch_cmd = [
+            'patch -p 1 -d gadget-plugin.git -i ../fix_reader_v60.patch']
     else:
         _patch_cmd = None
 

--- a/ci/scripts/alps.sh
+++ b/ci/scripts/alps.sh
@@ -360,7 +360,8 @@ launch_reframe_1arg() {
     export RFM_USE_LOGIN_SHELL=1
     # export RFM_AUTODETECT_XTHOSTNAME=1
     # reframe -V
-    echo "# UENV=$UENV"
+    export CSCS_RFM_UENV=$UENV
+    echo "# CSCS_RFM_UENV=$CSCS_RFM_UENV"
     echo "# args=$@"
     reframe -C ./config/cscs.py \
         --report-junit=report.xml \

--- a/config/utilities/uenv.py
+++ b/config/utilities/uenv.py
@@ -1,4 +1,3 @@
-import json
 import os
 import pathlib
 import yaml

--- a/config/utilities/uenv.py
+++ b/config/utilities/uenv.py
@@ -110,7 +110,9 @@ def _get_uenvs() -> Optional[List]:
 
     uenv_environments = []
     uenv_list = uenv.split(_UENV_DELIMITER)
-    uenv_version = osext.run_command(f'{_UENV_CLI} --version', shell=True).stdout.strip()
+    uenv_version = osext.run_command(
+        f'{_UENV_CLI} --version', shell=True
+    ).stdout.strip()
 
     for uenv in uenv_list:
         uenv_identifier, *uenv_mountpoint = uenv.split(_UENV_MOUNT_DELIMITER)
@@ -141,13 +143,13 @@ def _get_uenvs() -> Optional[List]:
             # Check that uenv was pulled
             if not image_path.is_file():
                 raise ConfigError(
-                    f"{uenv_name} is missing, try pulling it with: uenv image pull {uenv_name}"
-                )
+                    f"{uenv_name} is missing, "
+                    f"try pulling it with: uenv image pull {uenv_name}")
             try:
                 if image_path.stat().st_size == 0:
                     raise ConfigError(
-                        f"{uenv_name} is empty, try pulling it with: uenv image pull {uenv_name}"
-                    )
+                        f"{uenv_name} is empty, "
+                        f"try pulling it with: uenv image pull {uenv_name}")
             except FileNotFoundError:
                 raise ConfigError(f"{uenv_name} was not found")
 
@@ -162,9 +164,12 @@ def _get_uenvs() -> Optional[List]:
 
         try:
             with open(rfm_meta) as image_envs:
-                image_environments = yaml.load(image_envs.read(), Loader=yaml.BaseLoader)
+                image_environments = yaml.load(
+                    image_envs.read(), Loader=yaml.BaseLoader)
         except OSError as err:
-            print(f'Skipping uenv `{uenv}`, there was an error reading the metadata: {err}')
+            print(f'Skipping uenv `{uenv}`, there was an error '
+                  f'reading the metadata: {err}')
+
             continue
 
         for k, v in image_environments.items():
@@ -172,7 +177,9 @@ def _get_uenvs() -> Optional[List]:
             activation = v.pop('activation', [])
             views = v.pop('views', [])
 
-            env = {'target_systems': [target_system]}
+            env = {
+                'target_systems': [target_system]
+            }
             env.update(v)
 
             if isinstance(activation, list):

--- a/config/utilities/uenv.py
+++ b/config/utilities/uenv.py
@@ -13,8 +13,7 @@ _UENV_MOUNT_DEFAULT = '/user-environment'
 _UENV_CLI = 'uenv'
 _UENV_DELIMITER = ','
 _UENV_MOUNT_DELIMITER = '@'
-_UENV_LABEL_DELIMITER = '|'
-_UENV_NOLABEL = "nolabel"
+_UENV_LABEL_DELIMITER = '^'
 _RFM_META = pathlib.Path('extra') / 'reframe.yaml'
 _RFM_META_DIR = pathlib.Path('meta')
 
@@ -87,10 +86,10 @@ def _parse_uenv_identifier(
     """
 
     # uenv identifier can be either:
-    # - squashfs_path|uenv_label
+    # - squashfs_path^uenv_label (see _UENV_LABEL_DELIMITER)
     # - squashfs_path
     # - uenv_label
-    if "|" in uenv_identifier:
+    if _UENV_LABEL_DELIMITER in uenv_identifier:
         uenv_path, uenv_name = uenv_identifier.split(_UENV_LABEL_DELIMITER)
         uenv_path = pathlib.Path(uenv_path)
     elif pathlib.Path(uenv_identifier).is_file():

--- a/config/utilities/uenv.py
+++ b/config/utilities/uenv.py
@@ -103,7 +103,7 @@ def _parse_uenv_identifier(
 
 
 def _get_uenvs() -> Optional[List]:
-    uenv = os.environ.get('UENV', None)
+    uenv = os.environ.get('CSCS_RFM_UENV', None)
     if uenv is None:
         return uenv
 

--- a/config/utilities/uenv.py
+++ b/config/utilities/uenv.py
@@ -51,23 +51,33 @@ def uarch(partition):
     return None
 
 
-def uenv_metadata():
-    # import os
-    # import json
-    # from reframe.utility import osext
+def _uenv_version_and_tag_from_label(
+    uenv_label: Optional[str],
+) -> Tuple[Optional[str], Optional[str]]:
+    """
+    Given a uenv label "{name}/{ver}:{tag} it returns the tuple (ver, tag).
 
-    uenv_label = os.environ['UENV']
-    _uenv_version = osext.run_command(f'{_UENV_CLI} --version').stdout.strip()
+    Values are returned as str and any semantic is left to the user.
+    The only required component is the name; if any (or both) of the two is missing,
+    the related tuple component is considered not specified and set to None.
+    """
 
-    if Version(_uenv_version) >= Version('9.2.0'):
-        _cmd = f"{_UENV_CLI} image inspect --json {uenv_label}"
-        metadata = json.loads(osext.run_command(_cmd, shell=True).stdout)
-        return Version(metadata["version"]), Version(metadata["tag"])
+    if uenv_label is None or ("/" not in uenv_label and ":" not in uenv_label):
+        return (None, None)
+
+    if "/" not in uenv_label:
+        ver = None
+        rem = uenv_label
     else:
-        _cmd = f"{_UENV_CLI} image inspect --format=\'{{version}} {{tag}}\' {uenv_label}"  # noqa E501
-        _version_tag = osext.run_command(_cmd, shell=True).stdout
-        return str(_version_tag.split(" ")[0]), \
-            str(_version_tag.split(" ")[1])
+        _, rem = uenv_label.split("/")
+
+    if ":" not in rem:
+        ver = rem
+        tag = None
+    else:
+        ver, tag = rem.split(":")
+
+    return ver, tag
 
 
 def _parse_uenv_identifier(
@@ -185,6 +195,9 @@ def _get_uenvs() -> Optional[List]:
                 .replace("%", "_")
             )
             env['name'] = f'{uenv_name_pretty}_{k}'
+
+            env.setdefault("extras", {})["version"] = _uenv_version_and_tag_from_label(uenv_name)
+
             env['resources'] = {
                 'uenv': {
                     'file': str(image_path),

--- a/config/utilities/uenv.py
+++ b/config/utilities/uenv.py
@@ -3,6 +3,8 @@ import os
 import pathlib
 import yaml
 
+from typing import List, Optional, Tuple
+
 import reframe.utility.osext as osext
 from reframe.core.exceptions import ConfigError
 from packaging.version import Version
@@ -12,6 +14,8 @@ _UENV_MOUNT_DEFAULT = '/user-environment'
 _UENV_CLI = 'uenv'
 _UENV_DELIMITER = ','
 _UENV_MOUNT_DELIMITER = '@'
+_UENV_LABEL_DELIMITER = '|'
+_UENV_NOLABEL = "nolabel"
 _RFM_META = pathlib.Path('extra') / 'reframe.yaml'
 _RFM_META_DIR = pathlib.Path('meta')
 
@@ -66,27 +70,54 @@ def uenv_metadata():
             str(_version_tag.split(" ")[1])
 
 
-def _get_uenvs():
+def _parse_uenv_identifier(
+    uenv_identifier: str,
+) -> Tuple[Optional[str], Optional[pathlib.Path]]:
+    """
+    return: (name, path)
+    """
+
+    # uenv identifier can be either:
+    # - squashfs_path|uenv_label
+    # - squashfs_path
+    # - uenv_label
+    if "|" in uenv_identifier:
+        uenv_path, uenv_name = uenv_identifier.split(_UENV_LABEL_DELIMITER)
+        uenv_path = pathlib.Path(uenv_path)
+    elif pathlib.Path(uenv_identifier).is_file():
+        uenv_path = pathlib.Path(uenv_identifier)
+        uenv_name = None
+    else:
+        uenv_name = uenv_identifier
+        uenv_path = None
+
+    return (uenv_name, uenv_path)
+
+
+def _get_uenvs() -> Optional[List]:
     uenv = os.environ.get('UENV', None)
     if uenv is None:
         return uenv
 
     uenv_environments = []
     uenv_list = uenv.split(_UENV_DELIMITER)
-    uenv_version = osext.run_command(
-        f'{_UENV_CLI} --version', shell=True
-    ).stdout.strip()
+    uenv_version = osext.run_command(f'{_UENV_CLI} --version', shell=True).stdout.strip()
 
     for uenv in uenv_list:
-        uenv_name, *image_mount = uenv.split(_UENV_MOUNT_DELIMITER)
-        if len(image_mount) > 0:
-            image_mount = image_mount[0]
+        uenv_identifier, *uenv_mountpoint = uenv.split(_UENV_MOUNT_DELIMITER)
+        uenv_name, uenv_path = _parse_uenv_identifier(uenv_identifier)
+
+        if len(uenv_mountpoint) > 0:
+            uenv_mountpoint = uenv_mountpoint[0]
         else:
-            image_mount = None
+            uenv_mountpoint = None
 
         # Check if given uenv_name is a path to a squashfs archive
-        uenv_path = pathlib.Path(uenv_name)
-        if uenv_path.is_file():
+        if uenv_path:
+            if not uenv_path.is_file():
+                raise ConfigError(f"{uenv_name} is not a valid path to a squashfs uenv image")
+
+            # We cannot inspect for target systems
             target_system = '*'
             image_path = uenv_path
             rfm_meta = image_path.parent / _RFM_META_DIR / _RFM_META
@@ -101,13 +132,13 @@ def _get_uenvs():
             # Check that uenv was pulled
             if not image_path.is_file():
                 raise ConfigError(
-                    f"{uenv_name} is missing, "
-                    f"try pulling it with: uenv image pull {uenv_name}")
+                    f"{uenv_name} is missing, try pulling it with: uenv image pull {uenv_name}"
+                )
             try:
                 if image_path.stat().st_size == 0:
                     raise ConfigError(
-                        f"{uenv_name} is empty, "
-                        f"try pulling it with: uenv image pull {uenv_name}")
+                        f"{uenv_name} is empty, try pulling it with: uenv image pull {uenv_name}"
+                    )
             except FileNotFoundError:
                 raise ConfigError(f"{uenv_name} was not found")
 
@@ -122,12 +153,9 @@ def _get_uenvs():
 
         try:
             with open(rfm_meta) as image_envs:
-                image_environments = yaml.load(
-                    image_envs.read(), Loader=yaml.BaseLoader)
+                image_environments = yaml.load(image_envs.read(), Loader=yaml.BaseLoader)
         except OSError as err:
-            print(f'Skipping uenv `{uenv}`, there was an error '
-                  f'reading the metadata: {err}')
-
+            print(f'Skipping uenv `{uenv}`, there was an error reading the metadata: {err}')
             continue
 
         for k, v in image_environments.items():
@@ -135,9 +163,7 @@ def _get_uenvs():
             activation = v.pop('activation', [])
             views = v.pop('views', [])
 
-            env = {
-                'target_systems': [target_system]
-            }
+            env = {'target_systems': [target_system]}
             env.update(v)
 
             if isinstance(activation, list):
@@ -152,15 +178,21 @@ def _get_uenvs():
                 )
 
             # Replace characters that create problems in environment names
-            uenv_name_pretty = \
-                uenv_name.replace(":", "_").replace("/", "_").replace("%", "_")
+            uenv_name_pretty = (
+                (uenv_name if uenv_name else str(uenv_path))
+                .replace(":", "_")
+                .replace("/", "_")
+                .replace("%", "_")
+            )
             env['name'] = f'{uenv_name_pretty}_{k}'
             env['resources'] = {
                 'uenv': {
                     'file': str(image_path),
-                    'mount': image_mount,
-                    'uenv': f'{image_path}:{image_mount}' if image_mount
-                            else str(image_path)
+                    'mount': uenv_mountpoint,
+                    'uenv': (
+                        f'{str(image_path)}'
+                        f':{uenv_mountpoint if uenv_mountpoint else _UENV_MOUNT_DEFAULT}'
+                    ),
                 }
             }
             if len(views) > 0:


### PR DESCRIPTION
This is a proposal for introducing a small feature for uenv tests, where uenv label is made available to test as an [extras](https://reframe-hpc.readthedocs.io/en/stable/config_reference.html#config.environments.extras) attribute of the `environment` configuration section.

Unfortunately, uenv label is not something embedded in uenv squashfs images, and in UENV environment variable (the one controlling which uenvs are given to reframe) it is possible to specify either (a comma separated list of):
- squasfhs path
- uenv label (actually, restricted to just `name`, `version`, `tag` and `mountpoint`; no `system` nor `uarch`)

so, the label is not always available.

In particular, first option is used by `alps-uenv` CI. The interesting thing is that [CI knows the name and version of the uenv](https://github.com/eth-cscs/uenv-pipeline/blob/f5ecebac573acce425d443e6e1b2552abaf09e52/stage-test#L56-L60), but it is not passed to reframe. Hence, the idea is to add also a third option `squashfs|label`, so that reframe can acquire this information too.

Since there is not strict rule about versioning in uenv labels but just [guidelines](https://docs.cscs.ch/software/uenv/deploy/#versioning-and-labeling), I'm opting for extracting just the different fields, namely `version` and `tag`, if available, and pass it to the test, so that each one might process those information independently as the maintainer of the uenv decided to manage versioning.

With such information tests might be parametrized on both version and tag. It seems it is something that more then one tests might already benefit from, and hopefully this effort might become a common ground to avoid ending up with many custom implementations for the same thing (e.g. `cp2k` relies on `extras:version` defined in the uenv itself, which seems a bit redundant workaround).

FYI @bcumming @msimberg @jgphpc @RMeli