### PR TITLE
Add PyFR Container Engine check

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,8 +9,9 @@ $ reframe -r ...
 ```shell
 cscs-ci run alps-eiger-uenv;MY_UENV=[build::|service::]prgenv-gnu/25.11:v1
 
-cscs-ci run alps-daint-uenv;MY_UENV=prgenv-gnu/25.11:v1
-cscs-ci run alps-santis-uenv;MY_UENV=prgenv-gnu/25.11:v1
+cscs-ci run alps-daint-uenv;MY_UENV=prgenv-gnu/26.3:v1
+cscs-ci run alps-santis-uenv;MY_UENV=prgenv-gnu/26.3:v1
+cscs-ci run alps-clariden-uenv;MY_UENV=prgenv-gnu/26.3:v1
 cscs-ci run alps-starlex-uenv;MY_UENV=prgenv-gnu/25.11:v1
 
 cscs-ci run alps-beverin-uenv;MY_UENV=prgenv-gnu/25.07-6.3.3:v12

--- a/checks/containers/container_engine/pyfr.py
+++ b/checks/containers/container_engine/pyfr.py
@@ -1,0 +1,98 @@
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# ReFrame Project Developers. See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# The Containerfiles for the images used in these checks can be found at
+# https://github.com/sarus-suite/containerfiles-ci/tree/main/hpc/applications/pyfr
+
+import sys
+import pathlib
+import reframe as rfm
+import reframe.utility.sanity as sn
+
+sys.path.append(str(pathlib.Path(__file__).parent.parent.parent / 'mixins'))
+sys.path.append(str(pathlib.Path(__file__).parent.parent.parent.parent / 'config' / 'utilities'))
+
+from uenv import uarch                             # noqa: E402
+from container_engine import ContainerEngineMixin  # noqa: E402
+from slurm_mpi_pmix import SlurmMpiPmixMixin       # noqa: E402
+
+
+@rfm.simple_test
+class PyFR_CE(rfm.RunOnlyRegressionTest,
+              ContainerEngineMixin,
+              SlurmMpiPmixMixin):
+    descr = 'PyFR for CE'
+    valid_systems = ['+ce +nvgpu']
+    valid_prog_environs = ['builtin']
+    backend = parameter(['cuda'])
+    test_name = parameter(['3d-taylor-green-ci'])
+    maintainers = ['VCUE']
+    tags = {'production', 'ce_dev', 'maintenance'}
+
+    num_tasks = 2
+    num_tasks_per_node = 1
+    time_limit = '3m'
+
+    container_image = 'jfrog.svc.cscs.ch/ghcr/sarus-suite/containerfiles-ci/pyfr:2.1-ompi5.0.9-ofi1.22-cuda12.8.1'
+    container_workdir = '/pyfr-test-cases/3d-taylor-green'
+    container_env_table = {
+        'env': {
+            'UCX_WARN_UNUSED_ENV_VARS': 'n'
+        }
+    }
+    regex_sim_complete = (
+        r'100\.0.* 5.00/5.00 ela: 00:00:(?P<sec>\d+) rem: 00:00:00$')
+
+    reference_per_test = {
+        '3d-taylor-green-ci': {
+            'gh200': {
+                'elapsed': (18.0, -0.10, 0.10, 's')
+            },
+            'a100': {
+                'elapsed': (36.0, -0.10, 0.10, 's')
+            }
+        }
+    }
+
+    @run_after('setup')
+    def set_executable(self):
+        self.executable = f'pyfr'
+        self.executable_opts = [
+            f'-p',
+            f'run',
+            f'--backend {self.backend}',
+            f'taylor-green-p2.pyfrm',
+            f'taylor-green-ci.ini',
+        ]
+
+    @sanity_function
+    def assert_sanity(self):
+        s1 = sn.assert_found(self.regex_sim_complete, self.stderr)
+        return sn.all([s1])
+
+    @performance_function('s')
+    def elapsed(self):
+        return sn.extractsingle(self.regex_sim_complete, self.stderr, 'sec',
+                                float)
+
+    @run_before('performance')
+    def set_perf_reference(self):
+        self.uarch = uarch(self.current_partition)
+        if self.uarch is not None and \
+           self.uarch in self.reference_per_test[self.test_name]:
+            self.reference = {
+                self.current_partition.fullname:
+                    self.reference_per_test[self.test_name][self.uarch]
+            }
+
+
+@rfm.simple_test
+class PyFR_Skybox(PyFR_CE):
+    descr = 'PyFR for CE/Skybox'
+    tags = {'ce_dev', 'skybox'}
+    spank_option = 'edf'
+    container_env_key_values = {
+        'devices': ["alps.cscs/cxi=all", "nvidia.com/gpu=all", "/dev/gdrdrv"]
+    }

--- a/checks/mixins/container_engine.py
+++ b/checks/mixins/container_engine.py
@@ -12,6 +12,11 @@ from reframe.core.exceptions import EnvironError
 
 
 class ContainerEngineMixin(rfm.RegressionTestPlugin):
+    #: Slurm option to activate the SPANK plugin for container integration.
+    #:
+    #: :default: ``environment``
+    spank_option = variable(str, value='environment')
+
     #: The container image to use.
     #:
     #: :default: ``required``
@@ -32,15 +37,16 @@ class ContainerEngineMixin(rfm.RegressionTestPlugin):
     container_mounts = variable(typ.List[str], value=[])
 
     #: A dictionary of key/values to pass to the container environment.
+    #: Useful for setting arbitrary parameters in the EDF.
     #:
     #: :default: ``{}``
-    container_env_key_values = variable(typ.Dict[str, str], value={})
+    container_env_key_values = variable(typ.Dict[str, object], value={})
 
     #: A dictionary of tables to pass to the container environment.
     #: For each key, a dictionary of key/value pairs is given.
     #:
     #: :default: ``{}``
-    container_env_table= variable(typ.Dict[str, typ.Dict[str, str]], value={})
+    container_env_table = variable(typ.Dict[str, typ.Dict[str, str]], value={})
 
     @run_before('run')
     def create_env_file(self):
@@ -56,7 +62,7 @@ class ContainerEngineMixin(rfm.RegressionTestPlugin):
             toml_lines += [f'workdir = "{self.container_workdir}"']
 
         for k, v in self.container_env_key_values.items():
-            toml_lines.append(f'{k} = "{v}"')
+            toml_lines.append(f'{k} = {v}')
 
         for table_name, values in self.container_env_table.items():
             if values:
@@ -66,24 +72,24 @@ class ContainerEngineMixin(rfm.RegressionTestPlugin):
 
         self.env_file = f'{self.stagedir}/rfm_env.toml'
         with open(self.env_file, 'w') as f:
-            f.write('\n'.join(l for l in toml_lines if l))
+            f.write('\n'.join(ln for ln in toml_lines if ln))
 
     @run_before('run')
     def set_container_engine_env_launcher_options(self):
-        self.job.launcher.options += [f'--environment={self.env_file}']
+        self.job.launcher.options += [f'--{self.spank_option}={self.env_file}']
 
 
 class ContainerEngineCPEMixin(rfm.RegressionTestPlugin):
     @run_after('setup')
     def set_container_mounts(self):
-       current_environ = self.current_environ
-       self.build_locally = False
-       if 'cpe_ce_image' in current_environ.resources:
-           if os.environ.get('CPE_CE', None) is not None:
-               self.extra_resources = {
-                   'cpe_ce_mount': {
-                       'stagedir': self.stagedir
-                   }
-               }
-           else:
-               raise EnvironError("enviroment variable 'CPE_CE' is undefined")
+        current_environ = self.current_environ
+        self.build_locally = False
+        if 'cpe_ce_image' in current_environ.resources:
+            if os.environ.get('CPE_CE', None) is not None:
+                self.extra_resources = {
+                    'cpe_ce_mount': {
+                        'stagedir': self.stagedir
+                    }
+                }
+            else:
+                raise EnvironError("enviroment variable 'CPE_CE' is undefined")

--- a/checks/mixins/slurm_mpi_pmi2.py
+++ b/checks/mixins/slurm_mpi_pmi2.py
@@ -1,0 +1,16 @@
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# ReFrame Project Developers. See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import reframe as rfm
+
+
+class SlurmMpiPmi2Mixin(rfm.RegressionTestPlugin):
+    """
+    Set slurm --mpi flags for jobs that require PMI-2.
+    """
+
+    @run_after('setup')
+    def set_slurm_mpi_pmi2(self):
+        self.job.launcher.options += ['--mpi=pmi2']

--- a/checks/mixins/slurm_mpi_pmix.py
+++ b/checks/mixins/slurm_mpi_pmix.py
@@ -8,10 +8,8 @@ import reframe as rfm
 
 class SlurmMpiPmixMixin(rfm.RegressionTestPlugin):
     """
-    Set slurm --mpi flags for containers that require PMIx.
-
+    Set slurm --mpi flags for jobs that require PMIx.
     Containers that use OpenMPI require the --mpi=pmix flag.
-
     Additionally silence some warnings triggered by OpenMPI.
     """
 
@@ -22,7 +20,7 @@ class SlurmMpiPmixMixin(rfm.RegressionTestPlugin):
         # Disable MCA components to avoid warnings
         self.env_vars.update(
             {
-                'PMIX_MCA_psec': 'native',
+                'PMIX_MCA_psec': '^munge',
                 'PMIX_MCA_gds': '^shmem2'
             }
         )

--- a/checks/prgenv/mpi_cpi.py
+++ b/checks/prgenv/mpi_cpi.py
@@ -8,14 +8,24 @@ class cpi_build_test(rfm.RegressionTest):
     valid_systems = ['+remote']
     valid_prog_environs = ['+mpi']
     build_system = 'SingleSource'
-    sourcepath = 'mpi_cpi/cpi.c'
+    sourcesdir = 'src/mpi_cpi'
+    sourcepath = 'cpi.c'
     executable = './cpi.x'
-    num_tasks = -2
-    num_tasks_per_node = 1
+    _num_tasks = -2
+    # num_tasks_per_node = 1
     build_locally = False
     env_vars = {'MPICH_GPU_SUPPORT_ENABLED': 0}
     tags = {'appscheckout', 'uenv', 'flexible'}
     maintainers = ['VCUE', 'PA']
+    flexible = variable(bool, value=False)
+
+    @run_before('run')
+    def setup_job(self):
+        self.num_tasks = 0 if self.flexible else self._num_tasks
+        # if self.flexible:
+        #     self.num_tasks = 0
+        # else:
+        #     self.num_tasks = self.num_tasks_per_node
 
     @sanity_function
     def validate(self):


### PR DESCRIPTION
PyFR-scoped PR split from #550 

- Added checks featuring PyFR
- Introduced the `ce_dev` tag to mark checks of interest for continuous testing during CE development
- Introduced checks for the Skybox SPANK plugin (only tagged for development, no production or maintenance)
- Added mixin class for PMI2 Slurm option, mirroring the existing one for PMIx