### PR TITLE
Improve error handling for more robust test listing

### DIFF
--- a/checks/system/integration/v-cluster_config.py
+++ b/checks/system/integration/v-cluster_config.py
@@ -26,8 +26,16 @@ import json
 system_data_file = "cluster_data.json"
 
 # Read the extracted info from the json file
-with open(os.path.join(json_file_path, system_data_file), 'r') as json_file:
-    config_yaml_data = json.load(json_file)
+config_file_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                json_file_path,
+                                system_data_file)
+
+try:
+    with open(config_file_path, 'r') as json_file:
+        config_yaml_data = json.load(json_file)
+except FileNotFoundError as exc:
+    print(f"WARNING: V-Cluster config file not found: {config_file_path}: {exc}")
+    config_yaml_data = {}
 
 # Check for mount points to be checked
 mount_info = config_yaml_data.get(MOUNT_VARS[0])

--- a/checks/system/slurm/slurm.py
+++ b/checks/system/slurm/slurm.py
@@ -463,21 +463,23 @@ class SlurmPrologEpilogCheck(rfm.RunOnlyRegressionTest):
     epilog_dir = '/etc/slurm/node_epilog.d/'
     prerun_cmds = [f'ln -s {kafka_logger} ./kafka_logger']
     test_files = []
-    try:
-        for file in os.listdir(epilog_dir):
-            if os.path.isfile(os.path.join(epilog_dir, file)):
-                test_files.append(os.path.join(epilog_dir, file))
-    except (PermissionError, FileNotFoundError):
-        pass
 
-    try:
-        for file in os.listdir(prolog_dir):
-            if os.path.isfile(os.path.join(prolog_dir, file)):
-                test_files.append(os.path.join(prolog_dir, file))
-    except (PermissionError, FileNotFoundError):
-        pass
+    for directory in (epilog_dir, prolog_dir):
+        try:
+            if not os.path.isdir(directory):
+                continue
+            for file in os.listdir(directory):
+                file_path = os.path.join(directory, file)
+                if os.path.isfile(file_path):
+                    test_files.append(file_path)
+        except PermissionError:
+            pass
 
-    test_file = parameter(test_files)
+    if test_files:
+        test_file = parameter(test_files)
+    else:
+        valid_systems = []
+
     tags = {'vs-node-validator'}
 
     @run_after('setup')

--- a/checks/system/slurm/slurm.py
+++ b/checks/system/slurm/slurm.py
@@ -464,16 +464,19 @@ class SlurmPrologEpilogCheck(rfm.RunOnlyRegressionTest):
     prerun_cmds = [f'ln -s {kafka_logger} ./kafka_logger']
     test_files = []
 
-    for directory in (epilog_dir, prolog_dir):
-        try:
-            if not os.path.isdir(directory):
-                continue
-            for file in os.listdir(directory):
-                file_path = os.path.join(directory, file)
-                if os.path.isfile(file_path):
-                    test_files.append(file_path)
-        except PermissionError:
-            pass
+    try:
+        for file in os.listdir(epilog_dir):
+            if os.path.isfile(os.path.join(epilog_dir, file)):
+                test_files.append(os.path.join(epilog_dir, file))
+    except (PermissionError, FileNotFoundError):
+        pass
+
+    try:
+        for file in os.listdir(prolog_dir):
+            if os.path.isfile(os.path.join(prolog_dir, file)):
+                test_files.append(os.path.join(prolog_dir, file))
+    except (PermissionError, FileNotFoundError):
+        pass
 
     if test_files:
         test_file = parameter(test_files)

--- a/checks/system/slurm/slurm.py
+++ b/checks/system/slurm/slurm.py
@@ -467,14 +467,14 @@ class SlurmPrologEpilogCheck(rfm.RunOnlyRegressionTest):
         for file in os.listdir(epilog_dir):
             if os.path.isfile(os.path.join(epilog_dir, file)):
                 test_files.append(os.path.join(epilog_dir, file))
-    except PermissionError:
+    except (PermissionError, FileNotFoundError):
         pass
 
     try:
         for file in os.listdir(prolog_dir):
             if os.path.isfile(os.path.join(prolog_dir, file)):
                 test_files.append(os.path.join(prolog_dir, file))
-    except PermissionError:
+    except (PermissionError, FileNotFoundError):
         pass
 
     test_file = parameter(test_files)


### PR DESCRIPTION

- Goal of this PR is to avoid skipping any tests when listing all tests

```console
$ reframe -l  -C config/cscs.py -c checks --system daint --mode production
```

should not yield
```console
WARNING: skipping test file ...
```