### PR TITLE
add known failures to xfail tests

### DIFF
--- a/checks/apps/cp2k/cp2k_uenv.py
+++ b/checks/apps/cp2k/cp2k_uenv.py
@@ -24,7 +24,7 @@ cp2k_references = {
         'zen2': {'time_run': (75, None, 0.05, 's')}
     },
     'rpa': {
-        'gh200': {'time_run': (575, None, 0.05, 's')}
+        'gh200': {'time_run': xfail('Known performance regression', (575, None, 0.05, 's'))}
     },
 }
 

--- a/checks/apps/cp2k/cp2k_uenv.py
+++ b/checks/apps/cp2k/cp2k_uenv.py
@@ -11,15 +11,16 @@ import re
 import reframe as rfm
 import reframe.utility.sanity as sn
 import reframe.utility.udeps as udeps
+from reframe.core.builtins import xfail
 from uenv import uarch
 
 cp2k_references = {
     'md': {
-        'gh200': {'time_run': (45, None, 0.05, 's')},
+        'gh200': {'time_run': xfail('Known performance regression', (45, None, 0.05, 's'))},
         'zen2': {'time_run': (94, None, 0.05, 's')}
     },
     'pbe': {
-        'gh200': {'time_run': (51, None, 0.05, 's')},
+        'gh200': {'time_run': xfail('Known performance regression', (51, None, 0.05, 's'))},
         'zen2': {'time_run': (75, None, 0.05, 's')}
     },
     'rpa': {

--- a/checks/containers/container_engine/omb.py
+++ b/checks/containers/container_engine/omb.py
@@ -54,7 +54,8 @@ class OMB_Base_CE(rfm.RunOnlyRegressionTest, ContainerEngineMixin):
 
     @sanity_function
     def assert_sanity(self):
-        return sn.assert_found(self.sanity_per_test[self.test_name], self.stdout)
+        return sn.assert_found(self.sanity_per_test[self.test_name],
+                               self.stdout)
 
     @run_before('performance')
     def set_reference(self):
@@ -68,16 +69,17 @@ class OMB_Base_CE(rfm.RunOnlyRegressionTest, ContainerEngineMixin):
                                           self.stdout, 'bw_4M', float)
             },
             'collective/osu_alltoall': {
-                'latency_1M': sn.extractsingle(r'1048576\s+(?P<latency_1M>\S+)',
-                                     self.stdout, 'latency_1M', float)
-            }
+                'latency_1M': sn.extractsingle(
+                    r'1048576\s+(?P<latency_1M>\S+)', self.stdout,
+                    'latency_1M', float)
+                }
         }
         self.perf_patterns = self.patterns_per_test[self.test_name]
 
 
 @rfm.simple_test
 class OMB_MPICH_CE(OMB_Base_CE):
-    descr = 'OSU Micro-benchmarks for MPICH/CE (Point-to-Point and All-to-All)'
+    descr = 'OSU Micro-benchmarks for MPICH/CE (Point2Point and All2All)'
     container_image = (
         'jfrog.svc.cscs.ch#reframe-oci/osu-mb:7.5-mpich4.3.0-ofi1.15-cuda12.8'
     )
@@ -91,7 +93,6 @@ class OMB_MPICH_CE(OMB_Base_CE):
         'collective/osu_alltoall': {
             '*': {
                 'latency_1M': (1800., None, 0.15, 'us')
-                # 'latency_1M': xfail('Known performance regression', (1800., None, 0.15, 'us'))
             }
         }
     }
@@ -108,8 +109,10 @@ class OMB_MPICH_CE(OMB_Base_CE):
 
 @rfm.simple_test
 class OMB_OMPI_CE(OMB_Base_CE):
-    descr = 'OSU Micro-benchmarks for OpenMPI/CE (Point-to-Point and All-to-All)'
-    container_image = (f'jfrog.svc.cscs.ch#reframe-oci/osu-mb:7.5-ompi5.0.7-ofi1.15-cuda12.8')
+    descr = 'OSU Micro-benchmarks for OpenMPI/CE (Point2Point and All2All)'
+    container_image = (
+        'jfrog.svc.cscs.ch#reframe-oci/osu-mb:7.5-ompi5.0.7-ofi1.15-cuda12.8'
+    )
     valid_systems = ['+ce +nvgpu']
     reference_per_test = {
         'pt2pt/osu_bw': {
@@ -120,7 +123,6 @@ class OMB_OMPI_CE(OMB_Base_CE):
         'collective/osu_alltoall': {
             '*': {
                 'latency_1M': (500., None, 0.15, 'us')
-                # 'latency_1M': xfail('Known performance regression', (500., None, 0.15, 'us'))
             }
         }
     }

--- a/checks/containers/container_engine/omb.py
+++ b/checks/containers/container_engine/omb.py
@@ -8,6 +8,7 @@ import sys
 
 import reframe as rfm
 import reframe.utility.sanity as sn
+from reframe.core.builtins import xfail
 
 sys.path.append(str(pathlib.Path(__file__).parent.parent.parent / 'mixins'))
 
@@ -89,7 +90,7 @@ class OMB_MPICH_CE(OMB_Base_CE):
         },
         'collective/osu_alltoall': {
             '*': {
-                'latency_1M': (1800., None, 0.15, 'us')
+                'latency_1M': xfail('Known performance regression', (1800., None, 0.15, 'us'))
             }
         }
     }
@@ -112,7 +113,7 @@ class OMB_OMPI_CE(OMB_Base_CE):
         },
         'collective/osu_alltoall': {
             '*': {
-                'latency_1M': (500., None, 0.15, 'us')
+                'latency_1M': xfail('Known performance regression', (500., None, 0.15, 'us'))
             }
         }
     }

--- a/checks/containers/container_engine/omb.py
+++ b/checks/containers/container_engine/omb.py
@@ -90,10 +90,16 @@ class OMB_MPICH_CE(OMB_Base_CE):
         },
         'collective/osu_alltoall': {
             '*': {
-                'latency_1M': xfail('Known performance regression', (1800., None, 0.15, 'us'))
+                'latency_1M': (1800., None, 0.15, 'us')
+                # 'latency_1M': xfail('Known performance regression', (1800., None, 0.15, 'us'))
             }
         }
     }
+
+    @run_after('init')
+    def skip_xfail_test(self):
+        self.skip_if(self.test_name == 'collective/osu_alltoall',
+                     'skipping Known performance regression')
 
     @run_before('run')
     def set_pmi2(self):
@@ -113,10 +119,16 @@ class OMB_OMPI_CE(OMB_Base_CE):
         },
         'collective/osu_alltoall': {
             '*': {
-                'latency_1M': xfail('Known performance regression', (500., None, 0.15, 'us'))
+                'latency_1M': (500., None, 0.15, 'us')
+                # 'latency_1M': xfail('Known performance regression', (500., None, 0.15, 'us'))
             }
         }
     }
+
+    @run_after('init')
+    def skip_xfail_test(self):
+        self.skip_if(self.test_name == 'collective/osu_alltoall',
+                     'skipping Known performance regression')
 
     @run_before('run')
     def set_pmix(self):


### PR DESCRIPTION
This adds `xfail` for tests that we currently understand why they fail, but it will take time, until the system is fixed.
