### PR TITLE
Update DLA-Future tests with cuPointerGetAttribute workaround

### DIFF
--- a/checks/libraries/dlaf/dlaf.py
+++ b/checks/libraries/dlaf/dlaf.py
@@ -17,7 +17,7 @@ from uenv_slurm_mpi_options import UenvSlurmMpiOptionsMixin
 dlaf_references = {
     "eigensolver": {
         "gh200": {
-            "time_run": xfail("Known performance regression", (24.0, -0.1, 0.1, "s")),
+            "time_run": xfail("Known performance regression", (26.0, -0.1, 0.1, "s")),
         },
         "mi300": {
             "time_run": (36.0, -0.1, 0.1, "s"),
@@ -31,7 +31,7 @@ dlaf_references = {
     },
     "gen_eigensolver": {
         "gh200": {
-            "time_run": xfail("Known performance regression", (26.0, -0.1, 0.1, "s"))
+            "time_run": xfail("Known performance regression", (29.0, -0.1, 0.1, "s"))
         },
         "mi300": {
             "time_run": (47.0, -0.1, 0.1, "s")
@@ -118,9 +118,19 @@ slurm_config = {
 
 
 class dlaf_base(rfm.RunOnlyRegressionTest, UenvSlurmMpiOptionsMixin):
+    tags = {"uenv", "production", "bencher"}
     valid_systems = ['+uenv']
     valid_prog_environs = ['+dlaf -cp2k -cp2k-dev']
     maintainers = ['simbergm', 'rasolca', 'SSA']
+
+    test_name = parameter(["gen_eigensolver", "eigensolver"])
+    executable_opts = [
+        "--type=d",
+        "--matrix-size=40960",
+        "--check=last",
+        "--nwarmups=1",
+        "--nruns=1",
+    ]
 
     def _sq_factor(self, n):
         """
@@ -155,11 +165,10 @@ class dlaf_base(rfm.RunOnlyRegressionTest, UenvSlurmMpiOptionsMixin):
                 str((self.num_cpus_per_task // 2) - 1)
         else:
             self.env_vars["PIKA_THREADS"] = str(self.num_cpus_per_task - 1)
-        # This generally gives better performance, but causes:
-        # create_endpoint(1391).......: OFI EP enable failed (ofi_init.c:1391:create_endpoint:Invalid resource domain)
-        # on GH200 since the SLES 15 SP6 update.
-        # self.env_vars["MIMALLOC_ALLOW_LARGE_OS_PAGES"] = "1"
+        self.env_vars["MIMALLOC_ALLOW_LARGE_OS_PAGES"] = "1"
         self.env_vars["MIMALLOC_EAGER_COMMIT_DELAY"] = "0"
+        self.env_vars["MIMALLOC_ARENA_EAGER_COMMIT"] = "0"
+        self.env_vars["MIMALLOC_PURGE_DELAY"] = "-1"
         if self.uarch in ("gh200", "mi300", "mi200"):
             self.env_vars["FI_MR_CACHE_MONITOR"] = "disabled"
             self.env_vars["MPICH_GPU_SUPPORT_ENABLED"] = "1"
@@ -215,22 +224,29 @@ class dlaf_base(rfm.RunOnlyRegressionTest, UenvSlurmMpiOptionsMixin):
         regex = r"^\[0\]\s+(?P<perf>\S+)s\s+"
         return sn.extractsingle(regex, self.stdout, "perf", float)
 
-
-@rfm.simple_test
-class dlaf_check_uenv(dlaf_base):
-    tags = {"uenv", "production", "bencher"}
-    test_name = parameter(["gen_eigensolver", "eigensolver"])
-    executable_opts = [
-        "--type=d",
-        "--matrix-size=40960",
-        "--check=last",
-        "--nwarmups=1",
-        "--nruns=1",
-    ]
-
     @run_before("run")
     def set_executable(self):
         if uarch(self.current_partition) in ("mi300", "mi200"):
             self.executable = f"./rocr_wrapper.sh miniapp_{self.test_name}"
         else:
             self.executable = f"miniapp_{self.test_name}"
+
+
+@rfm.simple_test
+class dlaf_check_uenv(dlaf_base):
+    ...
+
+
+@rfm.simple_test
+class dlaf_check_uenv_cupointergetattributed_workaround(dlaf_base):
+    valid_systems += ['+nvgpu']
+
+    @run_before("run")
+    def ld_preload(self):
+        # CUDA driver 590 introduces a performance regression to
+        # cuPointerGetAttribute which slows down host buffer communication. The
+        # cuptrgetattr_override.so library overrides cuPointerGetAttribute and
+        # routes it to cuPointerGetAttributes which is faster.
+        if uarch(self.current_partition) == "gh200":
+            self.env_vars["LD_PRELOAD"] = \
+                "/capstor/store/cscs/cscs/public/temp/cuptrgetattr_override.so"

--- a/checks/libraries/dlaf/dlaf.py
+++ b/checks/libraries/dlaf/dlaf.py
@@ -12,18 +12,20 @@ from uenv import uarch
 
 sys.path.append(str(pathlib.Path(__file__).parent.parent.parent / 'mixins'))
 
-from uenv_slurm_mpi_options import UenvSlurmMpiOptionsMixin
+from uenv_slurm_mpi_options import UenvSlurmMpiOptionsMixin  # noqa:E402
 
 dlaf_references = {
     "eigensolver": {
         "gh200": {
-            "time_run": xfail("Known performance regression", (24.0, -0.1, 0.1, "s")),
+            "time_run":
+                xfail("Known performance regression", (24.0, -0.1, 0.1, "s")),
         },
         "mi300": {
             "time_run": (36.0, -0.1, 0.1, "s"),
         },
         "mi200": {
-            "time_run": xfail("Known performance regression", (41.0, -0.1, 0.1, "s")),
+            "time_run":
+                xfail("Known performance regression", (41.0, -0.1, 0.1, "s")),
         },
         "zen2": {
             "time_run": (170.0, -0.1, 0.1, "s"),
@@ -31,13 +33,15 @@ dlaf_references = {
     },
     "gen_eigensolver": {
         "gh200": {
-            "time_run": xfail("Known performance regression", (26.0, -0.1, 0.1, "s"))
+            "time_run":
+                xfail("Known performance regression", (26.0, -0.1, 0.1, "s"))
         },
         "mi300": {
             "time_run": (47.0, -0.1, 0.1, "s")
         },
         "mi200": {
-            "time_run": xfail("Known performance regression", (54.0, -0.1, 0.1, "s"))
+            "time_run":
+                xfail("Known performance regression", (54.0, -0.1, 0.1, "s"))
         },
         "zen2": {
             "time_run": (210.0, -0.1, 0.1, "s"),
@@ -243,6 +247,7 @@ class dlaf_base(rfm.RunOnlyRegressionTest, UenvSlurmMpiOptionsMixin):
             self.executable = f"./rocr_wrapper.sh miniapp_{self.test_name}"
         else:
             self.executable = f"miniapp_{self.test_name}"
+            self.prerun_cmds = ['cat /proc/driver/nvidia/version']
 
 
 @rfm.simple_test
@@ -268,6 +273,11 @@ class dlaf_check_uenv_cupointergetattributed_workaround(dlaf_base):
     def set_perf_reference(self):
         if self.uarch in dlaf_references[self.test_name]:
             self.reference = {
-                self.current_partition.fullname:
-                    dlaf_cupointergetattribute_references[self.test_name][self.uarch]
+                    self.current_partition.fullname: dlaf_cupointergetattribute_references[self.test_name][self.uarch]  # noqa:E501
             }
+
+    @performance_function('')
+    def nvidia_driver_version(self):
+        regex = r'^NVRM version: NVIDIA \w+( \w+){5}\s+(?P<version>\S+)'
+        return sn.extractsingle(regex, self.stdout, 'version',
+                                conv=lambda x: int(x.replace('.', '')))

--- a/checks/libraries/dlaf/dlaf.py
+++ b/checks/libraries/dlaf/dlaf.py
@@ -173,6 +173,7 @@ class dlaf_base(rfm.RunOnlyRegressionTest, UenvSlurmMpiOptionsMixin):
         self.ntasks_per_core = 1
         self.time_limit = config["walltime"]
         self.job.launcher.options += ["--cpu-bind=cores"]
+
         if self.uarch == "gh200":
             self.job.launcher.options += ["--gpus-per-task=1"]
 
@@ -182,10 +183,12 @@ class dlaf_base(rfm.RunOnlyRegressionTest, UenvSlurmMpiOptionsMixin):
                 str((self.num_cpus_per_task // 2) - 1)
         else:
             self.env_vars["PIKA_THREADS"] = str(self.num_cpus_per_task - 1)
+
         self.env_vars["MIMALLOC_ALLOW_LARGE_OS_PAGES"] = "1"
         self.env_vars["MIMALLOC_EAGER_COMMIT_DELAY"] = "0"
         self.env_vars["MIMALLOC_ARENA_EAGER_COMMIT"] = "0"
         self.env_vars["MIMALLOC_PURGE_DELAY"] = "-1"
+
         if self.uarch in ("gh200", "mi300", "mi200"):
             self.env_vars["FI_MR_CACHE_MONITOR"] = "disabled"
             self.env_vars["MPICH_GPU_SUPPORT_ENABLED"] = "1"
@@ -195,7 +198,7 @@ class dlaf_base(rfm.RunOnlyRegressionTest, UenvSlurmMpiOptionsMixin):
                 str(2**21)
 
         if self.uarch in ("mi300", "mi200"):
-            self.env_vars["MIMALLOC_ALLOW_LARGE_OS_PAGES"] = "1"
+            # self.env_vars["MIMALLOC_ALLOW_LARGE_OS_PAGES"] = "1"
             self.env_vars["PIKA_MPI_ENABLE_POOL"] = "1"
             self.env_vars["PIKA_MPI_COMPLETION_MODE"] = "28"
             self.env_vars["DLAF_BAND_TO_TRIDIAG_1D_BLOCK_SIZE_BASE"] = "2048"
@@ -247,7 +250,8 @@ class dlaf_base(rfm.RunOnlyRegressionTest, UenvSlurmMpiOptionsMixin):
             self.executable = f"./rocr_wrapper.sh miniapp_{self.test_name}"
         else:
             self.executable = f"miniapp_{self.test_name}"
-            self.prerun_cmds = ['cat /proc/driver/nvidia/version']
+            if uarch(self.current_partition) == 'gh200':
+                self.prerun_cmds += ['cat /proc/driver/nvidia/version']
 
 
 @rfm.simple_test
@@ -256,7 +260,7 @@ class dlaf_check_uenv(dlaf_base):
 
 
 @rfm.simple_test
-class dlaf_check_uenv_cupointergetattributed_workaround(dlaf_base):
+class dlaf_check_uenv_cupointergetattribute_workaround(dlaf_base):
     valid_systems += ['+nvgpu']
 
     @run_before("run")

--- a/checks/libraries/dlaf/dlaf.py
+++ b/checks/libraries/dlaf/dlaf.py
@@ -17,7 +17,7 @@ from uenv_slurm_mpi_options import UenvSlurmMpiOptionsMixin
 dlaf_references = {
     "eigensolver": {
         "gh200": {
-            "time_run": xfail("Known performance regression", (26.0, -0.1, 0.1, "s")),
+            "time_run": xfail("Known performance regression", (24.0, -0.1, 0.1, "s")),
         },
         "mi300": {
             "time_run": (36.0, -0.1, 0.1, "s"),
@@ -31,7 +31,7 @@ dlaf_references = {
     },
     "gen_eigensolver": {
         "gh200": {
-            "time_run": xfail("Known performance regression", (29.0, -0.1, 0.1, "s"))
+            "time_run": xfail("Known performance regression", (26.0, -0.1, 0.1, "s"))
         },
         "mi300": {
             "time_run": (47.0, -0.1, 0.1, "s")
@@ -41,6 +41,19 @@ dlaf_references = {
         },
         "zen2": {
             "time_run": (210.0, -0.1, 0.1, "s"),
+        }
+    },
+}
+
+dlaf_cupointergetattribute_references = {
+    "eigensolver": {
+        "gh200": {
+            "time_run": (26.0, -0.1, 0.1, "s"),
+        }
+    },
+    "gen_eigensolver": {
+        "gh200": {
+            "time_run": (29.0, -0.1, 0.1, "s")
         }
     },
 }
@@ -196,9 +209,9 @@ class dlaf_base(rfm.RunOnlyRegressionTest, UenvSlurmMpiOptionsMixin):
         else:
             self.executable_opts.append("--block-size=512")
 
-        # set performance reference
-        if self.uarch is not None and \
-           self.uarch in dlaf_references[self.test_name]:
+    @run_before("run")
+    def set_perf_reference(self):
+        if self.uarch in dlaf_references[self.test_name]:
             self.reference = {
                 self.current_partition.fullname:
                     dlaf_references[self.test_name][self.uarch]
@@ -250,3 +263,11 @@ class dlaf_check_uenv_cupointergetattributed_workaround(dlaf_base):
         if uarch(self.current_partition) == "gh200":
             self.env_vars["LD_PRELOAD"] = \
                 "/capstor/store/cscs/cscs/public/temp/cuptrgetattr_override.so"
+
+    @run_before("run")
+    def set_perf_reference(self):
+        if self.uarch in dlaf_references[self.test_name]:
+            self.reference = {
+                self.current_partition.fullname:
+                    dlaf_cupointergetattribute_references[self.test_name][self.uarch]
+            }


### PR DESCRIPTION
Updates the dlaf test with slightly better environment variables for mimalloc. The main test still stays xfail.

Also adds a separate test which uses the cuPointerGetAttribute override library for better performance. This test only runs on nvidia systems and should not xfail.

I've run this on daint and starlex with `UENV=$(uenv image inspect --format={path} linalg/25.10:v1@daint)/store.squashfs reframe -C config/cscs.py --name dlaf_check_uenv -c checks/ --run` and all tests pass or xfail.