### PR TITLE
CE: Don't call srun in Megatron-LM setup

### DIFF
--- a/checks/containers/container_engine/pytorch_megatronlm.py
+++ b/checks/containers/container_engine/pytorch_megatronlm.py
@@ -102,7 +102,8 @@ class PyTorchMegatronLM(rfm.RunOnlyRegressionTest):
         model_config = self.configurations[self.model]
         self.env_vars = {
             'CUDA_DEVICE_MAX_CONNECTIONS': 1,
-            'MASTER_ADDRESS': '$(scontrol show hostnames "$SLURM_JOB_NODELIST" | head -n 1)',
+            'MASTER_ADDRESS':
+                '$(scontrol show hostnames "$SLURM_JOB_NODELIST" | head -n 1)',
             'MASTER_PORT': '28400',
             'WORLD_SIZE': f'{self.num_nodes * self.num_gpus_per_node}',
             'OMP_NUM_THREADS': '72'

--- a/checks/containers/container_engine/pytorch_megatronlm.py
+++ b/checks/containers/container_engine/pytorch_megatronlm.py
@@ -102,7 +102,7 @@ class PyTorchMegatronLM(rfm.RunOnlyRegressionTest):
         model_config = self.configurations[self.model]
         self.env_vars = {
             'CUDA_DEVICE_MAX_CONNECTIONS': 1,
-            'MASTER_ADDRESS': '$(srun -A csstaff -N1 hostname)',
+            'MASTER_ADDRESS': '$(scontrol show hostnames "$SLURM_JOB_NODELIST" | head -n 1)',
             'MASTER_PORT': '28400',
             'WORLD_SIZE': f'{self.num_nodes * self.num_gpus_per_node}',
             'OMP_NUM_THREADS': '72'


### PR DESCRIPTION
The hard-coded call to `srun` in a preparatory function before the check has several downsides, most prominently not adapting to cluster conditions (e.g. default Slurm partition not usable), and making ReFrame's `--dry-run` dependent on a runnable Slurm job step.

This PR substitutes the `srun` command with an `scontrol` command, which does not require to run a job step.