### PR TITLE
Add OMB and NCCL CE check variants using host netstack

### DIFF
--- a/checks/containers/container_engine/omb.py
+++ b/checks/containers/container_engine/omb.py
@@ -152,6 +152,30 @@ class OMB_OMPI_CE(OMB_Base_CE, SlurmMpiPmixMixin):
 
 
 @rfm.simple_test
+class OMB_MPICH_CE_Host(OMB_MPICH_CE):
+    descr = '''
+    OSU Micro-benchmarks for MPICH/CE with host netstack (Point-to-Point & All-to-All)
+    '''
+    @run_after('init')
+    def setup_netstack_source(self):
+        self.container_env_table['annotations.com.hooks'].update({
+            'netstack.source': 'host'
+        })
+
+
+@rfm.simple_test
+class OMB_OMPI_CE_Host(OMB_OMPI_CE):
+    descr = '''
+    OSU Micro-benchmarks for OpenMPI/CE with host netstack (Point-to-Point & All-to-All)
+    '''
+    @run_after('init')
+    def setup_netstack_source(self):
+        self.container_env_table['annotations.com.hooks'].update({
+            'netstack.source': 'host'
+        })
+
+
+@rfm.simple_test
 class OMB_MPICH_Skybox(OMB_MPICH_CE):
     descr = '''
     OSU Micro-benchmarks for MPICH/CE/Skybox (Point-to-Point & All-to-All)

--- a/checks/containers/container_engine/omb.py
+++ b/checks/containers/container_engine/omb.py
@@ -154,8 +154,10 @@ class OMB_OMPI_CE(OMB_Base_CE, SlurmMpiPmixMixin):
 @rfm.simple_test
 class OMB_MPICH_CE_Host(OMB_MPICH_CE):
     descr = '''
-    OSU Micro-benchmarks for MPICH/CE with host netstack (Point-to-Point & All-to-All)
+    OSU Micro-benchmarks for MPICH/CE with host netstack
+    (Point2Point and All2All)
     '''
+
     @run_after('init')
     def setup_netstack_source(self):
         self.container_env_table['annotations.com.hooks'].update({
@@ -166,8 +168,10 @@ class OMB_MPICH_CE_Host(OMB_MPICH_CE):
 @rfm.simple_test
 class OMB_OMPI_CE_Host(OMB_OMPI_CE):
     descr = '''
-    OSU Micro-benchmarks for OpenMPI/CE with host netstack (Point-to-Point & All-to-All)
+    OSU Micro-benchmarks for OpenMPI/CE with host netstack
+    (Point2Point and All2All)
     '''
+
     @run_after('init')
     def setup_netstack_source(self):
         self.container_env_table['annotations.com.hooks'].update({

--- a/checks/microbenchmarks/xccl/xccl_tests.py
+++ b/checks/microbenchmarks/xccl/xccl_tests.py
@@ -172,7 +172,18 @@ class NCCLTestsCE(XCCLTestsBaseCE):
     @run_after('init')
     def setup_ce(self):
         self.container_env_table['annotations.com.hooks'].update({
-            'aws_ofi_nccl.variant': 'cuda12'
+            'aws_ofi_nccl.variant': 'cuda-dl'
+        })
+
+
+@rfm.simple_test
+class NCCLTestsCEHost(NCCLTestsCE):
+    descr = 'Point-to-Point and All-Reduce NCCL tests with CE and host netstack'
+
+    @run_after('init')
+    def setup_netstack_source(self):
+        self.container_env_table['annotations.com.hooks'].update({
+            'netstack.source': 'host'
         })
 
 
@@ -181,10 +192,6 @@ class NCCLTestsSkybox(NCCLTestsCE):
     descr = 'Point-to-Point and All-Reduce NCCL tests with CE/Skybox'
     tags = {'ce_dev', 'skybox'}
     spank_option = 'edf'
-    container_image = (
-        'jfrog.svc.cscs.ch/ghcr/sarus-suite/containerfiles-ci/'
-        'nccl-tests:2.17.9-ompi5.0.9-ofi1.22-cuda12.8.1')
-    container_workdir = '/nccl-tests-2.17.9/build/'
     container_env_key_values = {
         'devices': ["alps.cscs/cxi=all", "nvidia.com/gpu=all",
                     "alps.cscs/aws-ofi-nccl=cuda-dl", "/dev/gdrdrv"]
@@ -192,7 +199,9 @@ class NCCLTestsSkybox(NCCLTestsCE):
 
     @run_after('init')
     def setup_ce(self):
-        nccl_plugin_variant = 'cuda-dl'
+        self.container_env_table['annotations.com.hooks'].update({
+            'aws_ofi_nccl.variant': 'cuda-dl'
+        })
         # not used by Skybox right now but kept for consistency
 
 


### PR DESCRIPTION
The latest v26.06.1 CE vService (deployed in production in the upcoming June 17th maintenance) introduces [netstack artifacts](https://docs.cscs.ch/software/container-engine/resource-hook/#selecting-the-network-stack-source) as first-class resources mounted in containers for optimized Slingshot connectivity. Clariden and Daint use netstack artifacts by default.

Considering that artifacts are expected to be increasingly adopted as default across Alps, in order to continue checking that the configuration for host HPE libraries works as expected, this PR introduces variants of CE checks for OMB and NCCL (the essential indicators of network performance) which use explicitly the host netstack.

This is mainly meant to be a transitional arrangement.
- In vClusters which adopt artifacts as default, normal CE checks exercise the artifacts, while the new variants exercise the HPE native libs.
- In vClusters which continue to use the native HPE libs as default, the new check variants are equivalent to previously existing tests, while consuming very small allocation time
- If in the future all vClusters transition to use exclusively netstack artifacts, the check variants for host netstack can be cleanly removed
