### PR TITLE
[eiger] Define failing libfabric check as xfail

### DIFF
--- a/checks/system/integration/alps.py
+++ b/checks/system/integration/alps.py
@@ -803,6 +803,7 @@ def create_checks(check):
         descr='Verify system libfabric host directory is present',
         valid_systems=['daint', 'eiger', 'santis', 'clariden'],
         not_expected=r'FAILED',
+        xfail=('Missing host directory on Eiger', lambda test: test.current_system.name == 'eiger'),
     )
 
     # ----------------------------------------------------------------------- #

--- a/checks/system/integration/utils.py
+++ b/checks/system/integration/utils.py
@@ -61,7 +61,7 @@ class Check:
 
     def __call__(self, cmd, expected=None, not_expected=None, where=None, *,
                  name=None, descr=None, valid_systems=None,
-                 valid_prog_environs=None, tags=None):
+                 valid_prog_environs=None, tags=None, xfail=None):
         """
         Create a test of 'cmd'. A regex describing the expected output
 
@@ -229,4 +229,11 @@ class Check:
             ],
             module=self.MODULE_NAME
         )
+
+        if xfail is not None:
+            if isinstance(xfail, str):
+                t = rfm.xfail(xfail)(t)
+            elif isinstance(xfail, tuple):
+                t = rfm.xfail(xfail[0], xfail[1])(t)
+
         rfm.simple_test(t)


### PR DESCRIPTION
-  Describe the purpose of this pull request 
   - Define 'libfabric-host-directory' as xfail on Eiger 
        - this is temporary, the test will fail once Eiger is updated
   - adapt utils.py to support `xfail`conditionally applying `xfail` based on a reason and a predicate function.
   -    -    - 
```shell

 reframe -C ./config/cscs.py -c checks/system/integration/alps.py -n libfabric-host-directory -r

[==========] Running 1 check(s)
[==========] Started on Thu Jun 18 11:02:28 2026+0200

[----------] start processing checks
[ RUN      ] libfabric-host-directory /e36cf1e6 @eiger:login+builtin
[ RUN      ] libfabric-host-directory /e36cf1e6 @eiger:normal+builtin
[    XFAIL ] (1/2) libfabric-host-directory /e36cf1e6 @eiger:login+builtin [Missing host directory on Eiger]
[    XFAIL ] (2/2) libfabric-host-directory /e36cf1e6 @eiger:normal+builtin [Missing host directory on Eiger]
[----------] all spawned checks have finished

[  PASSED  ] Ran 2/2 test case(s) from 1 check(s) (0 failure(s), 2 expected failure(s), 0 skipped, 0 aborted)
[==========] Finished on Thu Jun 18 11:02:34 2026+0200

```
