### PR TITLE
rename UENV environment variable to CSCS_RFM_UENV

### DIFF
--- a/checks/apps/cp2k/cp2k_uenv.py
+++ b/checks/apps/cp2k/cp2k_uenv.py
@@ -84,7 +84,7 @@ slurm_config = {
 
 
 def version_from_uenv():
-    uenv_var = os.environ['UENV']
+    uenv_var = os.environ['CSCS_RFM_UENV']
     match = re.search(r'/(\d+\.\d+)', uenv_var)
     if match: # Return version (YYYY.VV)
         return match.group(1)

--- a/checks/apps/q-e-sirius/q-e-sirius_check_uenv.py
+++ b/checks/apps/q-e-sirius/q-e-sirius_check_uenv.py
@@ -59,7 +59,7 @@ slurm_config = {
 
 
 def uenv_uarch():
-    uenv_name = os.environ.get("UENV", None)
+    uenv_name = os.environ.get("CSCS_RFM_UENV", None)
     if not uenv_name:
         return uenv_name
     uenv_inspect_cmd = f"uenv image inspect --format={{uarch}} {uenv_name}"

--- a/checks/libraries/io/hdf5.py
+++ b/checks/libraries/io/hdf5.py
@@ -49,7 +49,7 @@ class CPE_HDF5Test(HDF5TestBase):
     @run_after('init')
     def skip_uenv_tests(self):
         # it seems that valid_prog_environs ignores -uenv
-        self.skip_if(os.environ.get("UENV") is not None)
+        self.skip_if(os.environ.get("CSCS_RFM_UENV") is not None)
 
 
 @rfm.simple_test

--- a/checks/prgenv/cuda/cuda_nvml.py
+++ b/checks/prgenv/cuda/cuda_nvml.py
@@ -75,7 +75,7 @@ class CPE_NVML(CudaNvmlBase, ContainerEngineCPEMixin):
     @run_after('init')
     def skip_uenv_tests(self):
         # it seems that valid_prog_environs ignores -uenv
-        self.skip_if(os.environ.get("UENV") is not None)
+        self.skip_if(os.environ.get("CSCS_RFM_UENV") is not None)
 
     @run_after('setup')
     def setup_modules(self):

--- a/checks/system/slurm/invalid_acc.py
+++ b/checks/system/slurm/invalid_acc.py
@@ -25,7 +25,7 @@ class InvalidAccount(rfm.RunOnlyRegressionTest):
 
     @run_before('setup')
     def skip_on_uenv(self):
-        self.skip_if('UENV' in os.environ, 'Skipping when UENV is set')
+        self.skip_if('CSCS_RFM_UENV' in os.environ, 'Skipping when CSCS_RFM_UENV is set')
 
     @sanity_function
     def validate(self):


### PR DESCRIPTION
Update various checks to use the new CSCS_RFM_UENV environment variable instead of the deprecated UENV variable.
- side effect from
   - https://github.com/eth-cscs/cscs-reframe-tests/pull/574
