### PR TITLE
Fix uenv handling

### DIFF
--- a/checks/apps/cp2k/cp2k_uenv.py
+++ b/checks/apps/cp2k/cp2k_uenv.py
@@ -105,7 +105,7 @@ class cp2k_download(rfm.RunOnlyRegressionTest):
     @run_before('run')
     def set_version(self):
         try:
-            uenv_version = self.current_environ.extras['version'][1:]
+            uenv_version = self.current_environ.extras['version'][0]
         except (KeyError, AttributeError):
             uenv_version = version_from_uenv()
 
@@ -354,7 +354,7 @@ class Cp2kCheckPBE_UENV(Cp2kCheck_UENV):
         # a different count means a different runtime with the same input file
         # See https://github.com/cp2k/cp2k/pull/4141
         try:
-            uenv_version = self.current_environ.extras['version'][1:]
+            uenv_version = self.current_environ.extras['version'][0]
         except (KeyError, AttributeError):
             uenv_version = version_from_uenv()
 

--- a/config/utilities/uenv.py
+++ b/config/utilities/uenv.py
@@ -208,8 +208,7 @@ def _get_uenvs() -> Optional[List]:
                     'file': str(image_path),
                     'mount': uenv_mountpoint,
                     'uenv': (
-                        f'{str(image_path)}'
-                        f':{uenv_mountpoint if uenv_mountpoint else _UENV_MOUNT_DEFAULT}'
+                        f'{str(image_path):{uenv_mountpoint}}' if uenv_mountpoint else str(image_path)
                     ),
                 }
             }


### PR DESCRIPTION
This fixes 2 problems that were introduced with #574 

1. A problem with cp2k version. The variable `current_environ.extras['version']` is now set by `config/utilities/uenv.py`, but it is not in the expected format of what cp2k would want.
2. A problem with `ascent` uenv, where the default mountpoint is `/user-tools`, but PR #574 makes `/user-environment` the default for every uenv, unless explicitly overwritten in the variable `CSCS_RFM_UENV="ascent/<ver>@/user-tools"`. This reverts the behaviour, and just leaves the mountpoint unspecified, i.e. the uenv tooling chooses the mountpoint.