### PR TITLE
Temporarily remove OOM test from production

### DIFF
--- a/checks/system/slurm/slurm.py
+++ b/checks/system/slurm/slurm.py
@@ -181,7 +181,7 @@ class MemoryOverconsumptionCheck(SlurmCompiledBaseCheck):
     descr = 'Tests if requested memory limit works'
     valid_prog_environs = ['+uenv -cpe +prgenv']
     time_limit = '2m'
-    tags.add('mem')
+    tags = {'slurm', 'maintenance', 'ops', 'mem', 'single-node'}
     build_system = 'SingleSource'
     sourcepath = 'eatmem/eatmemory.c'
     executable_opts = ['4000M']


### PR DESCRIPTION
- Removed production tag in order to avoid failiures
   - while this PR is not ready
         - https://github.com/eth-cscs/cscs-reframe-tests/pull/608