### PR TITLE
Update reframe container for TRE

### DIFF
--- a/containers/reframe/Containerfile-develop
+++ b/containers/reframe/Containerfile-develop
@@ -1,20 +1,16 @@
 FROM ubuntu:24.04
 
-# Install ca-certificates first using the default Ubuntu sources, so that the
-# subsequent switch to the internal CSCS HTTPS mirror can be verified.
+# Install ca-certificates first using the default Ubuntu sources.
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# Switch to the internal CSCS Ubuntu mirror for faster package downloads.
+# Switch to the internal CSCS Ubuntu mirror.
 COPY apt-workaround/ubuntu.sources /etc/apt/sources.list.d/ubuntu.sources
 COPY apt-workaround/99-jfrog-proxy /etc/apt/apt.conf.d/99-jfrog-proxy
 
 # Install system dependencies and libraries required by the host's Slurm CLI plugins.
-# The host Slurm plugins (SLES 15 SP6) are linked against OpenLDAP 2.4 and SASL2 .3,
-# while Ubuntu 24.04 ships OpenLDAP 2.5 / SASL2 .2. Compatibility symlinks are added
-# below to allow sbatch/srun to load the host plugins inside the container.
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         curl git build-essential lmod less \
@@ -35,12 +31,11 @@ RUN for d in /usr/lib/aarch64-linux-gnu /usr/lib/x86_64-linux-gnu; do \
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 ENV PATH="/root/.local/bin:${PATH}"
 
-# Install ReFrame 4.10.1 from the upstream git tag in editable mode.
-# Editable mode is used so that hpctestlib (which is not shipped in the PyPI
-# wheel) is also importable from /opt/reframe.
-RUN git clone --depth 1 --branch v4.10.1 https://github.com/reframe-hpc/reframe.git /opt/reframe
+# Install the latest ReFrame development version from the upstream repository
+# in editable mode, so hpctestlib is available alongside reframe.
+RUN git clone --depth 1 https://github.com/reframe-hpc/reframe.git /opt/reframe
 
-# Patch ReFrame 4.10.1 scheduler bug (KeyError in _cancel_if_blocked),
+# Patch ReFrame scheduler bug (KeyError in _cancel_if_blocked),
 # fixed upstream in https://github.com/reframe-hpc/reframe/pull/3695.
 # Remove this patch after upgrading to ReFrame >= 4.10.2.
 # Upstream code uses `pending_reasons[pending_job].setdefault([])` which raises
@@ -63,8 +58,7 @@ RUN uv tool install -e /opt/reframe --with packaging
 # declared reframe package, so it is not exposed by the editable install).
 ENV PYTHONPATH=/opt/reframe
 
-# Also make reframe available in a standard PATH location, so the binary is
-# reachable even if the container runtime resets PATH.
+# Also make reframe available in a standard PATH location.
 RUN ln -sf /root/.local/bin/reframe /usr/local/bin/reframe
 
 # Verify installation.

--- a/containers/reframe/README.md
+++ b/containers/reframe/README.md
@@ -1,0 +1,110 @@
+# ReFrame container workflow for clariden and lys
+
+This directory contains the container image and job scripts used to build and
+run the CSCS ReFrame test suite inside an enroot/Pyxis container on **clariden**
+and on **lys** (via FirecREST, no SSH required).
+
+The workflow uses a single shared container environment file
+(`reframe.toml`) that resolves `${SCRATCH}` to the correct scratch path on each
+system.
+
+## Prerequisites
+
+- Clariden/Daint
+  -  `podman` and `enroot` available on a compute node.
+- Lys:
+  - FirecREST CLI configured. 
+     - pyfirecrest and credentials
+- `jq` installed (used by the lys driver scripts to parse `firecrest systems`).
+
+## File summary
+
+| File | Purpose |
+|---|---|
+| `Containerfile-release` | Container definition for the release image (Ubuntu 24.04 + ReFrame 4.10.1 + CSCS checks). |
+| `Containerfile-develop` | Alternative container definition for development. |
+| `apt-workaround/` | Internal CSCS Ubuntu mirror configuration injected into the container build. |
+| `reframe.toml` | Shared Pyxis environment file. Image, mounts and workdir are based on `${SCRATCH}/reframe`. |
+| `build-release.sh` | Build the image **locally on clariden** and export it to `${SCRATCH}/reframe/ce-images/...`. |
+| `build-release-lys.sh` | Batch recipe that builds the image **natively on a lys compute node**. |
+| `build-on-lys.sh` | Clariden driver that uploads the build context to lys and submits `build-release-lys.sh` via FirecREST. |
+| `test-on-lys.sh` | Clariden driver that uploads the test scripts to lys and submits the ReFrame smoke test via FirecREST. |
+| `submit-reframe-clariden.sh` | Batch script to run the ReFrame tests inside the container on clariden. |
+| `submit-reframe-lys-firecrest.sh` | Batch script to run the ReFrame smoke test inside the container on lys. |
+| `submit-reframe-daint.sh` | Batch script for running the tests on daint. |
+| `deploy-image-to-lys.sh` | Fallback driver: upload a pre-built sqsh image from clariden to lys via FirecREST. |
+
+## Usage
+
+### clariden
+
+Run from a compute node in this directory:
+
+```bash
+./build-release.sh
+sbatch submit-reframe-clariden.sh
+```
+
+The image is written to `${SCRATCH}/reframe/ce-images/reframe-release.sqsh`.
+`submit-reframe-clariden.sh` loads the environment from
+`${SCRATCH}/reframe/reframe.toml`.
+
+### lys (via FirecREST from clariden)
+
+Build the image natively on lys:
+
+```bash
+./build-on-lys.sh
+```
+
+Run the smoke test:
+
+```bash
+./test-on-lys.sh
+```
+
+Both scripts derive the remote user and scratch path from FirecREST, upload the
+necessary files, submit the batch job, wait for completion and download the
+Slurm output log.
+
+### Fallback: upload a pre-built image to lys
+
+If the native lys build does not work, build on clariden and upload:
+
+```bash
+./build-release.sh
+./deploy-image-to-lys.sh
+```
+
+Then run the test as usual:
+
+```bash
+./test-on-lys.sh
+```
+
+## Notes
+
+- `reframe.toml` is shared between clariden and lys. Each system expands
+  `${SCRATCH}` to its own scratch filesystem, and the `.reframe` directory is
+  kept under `${SCRATCH}/reframe/.reframe` while being mounted at
+  `${HOME}/.reframe` inside the container.
+
+- On lys, compute nodes have no systemd user session, so `/run/user/<uid>`
+  does not exist and podman cannot use the default systemd cgroup manager.
+  `build-release-lys.sh` works around this by setting
+  `XDG_RUNTIME_DIR=/tmp/podman-run-${USER}` and writing a `containers.conf`
+  with `cgroup_manager = "cgroupfs"`.
+
+- On lys, `/vast/scratch` is a network filesystem that does not support the
+  extended attributes required by podman's overlay storage driver.
+  `build-release-lys.sh` keeps podman's image layers on local tmpfs by setting
+  `XDG_DATA_HOME=/tmp/podman-data-${USER}`.
+
+- On lys, `enroot import` may return exit code 1 even after successfully
+  creating the sqsh image; `build-release-lys.sh` captures the code and
+  verifies the artifact explicitly.
+
+- On lys, GID mismatch (transient / not reproduced): the job was observed running
+  with group `workspace36` while `/etc/passwd` listed `workspace39`, causing
+  `newuidmap` to reject rootless user namespaces. This has not been reproduced
+  recently. If needed, wrap podman and enroot calls with `sg workspace39`.

--- a/containers/reframe/apt-workaround/99-jfrog-proxy
+++ b/containers/reframe/apt-workaround/99-jfrog-proxy
@@ -1,0 +1,2 @@
+Acquire::http::AllowRedirect "true";
+Acquire::http::Pipeline-Depth "0";

--- a/containers/reframe/apt-workaround/ubuntu.sources
+++ b/containers/reframe/apt-workaround/ubuntu.sources
@@ -1,0 +1,11 @@
+Types: deb
+URIs: https://jfrog.svc.cscs.ch/artifactory/ubuntu-ports/
+Suites: noble noble-updates noble-backports
+Components: main universe restricted multiverse
+Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+
+Types: deb
+URIs: https://jfrog.svc.cscs.ch/artifactory/ubuntu-ports/
+Suites: noble-security
+Components: main universe restricted multiverse
+Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg

--- a/containers/reframe/build-on-lys.sh
+++ b/containers/reframe/build-on-lys.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# Local driver script (runs on clariden) that builds the ReFrame container
+# image natively on lys via FirecREST.
+
+set -euo pipefail
+
+# PRE-REQ: Load FirecREST environment and CLI.
+
+
+export FIRECREST_SYSTEM=lys
+
+# Derive remote user and scratch path from FirecREST.
+REMOTE_USER=$(firecrest id | awk -F'[()]' '{print $2}')
+REMOTE_SCRATCH=$(firecrest systems | jq -r '.[0].fileSystems[] | select(.dataType=="scratch") | .path')
+REMOTE_DIR="${REMOTE_SCRATCH}/${REMOTE_USER}/reframe"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "==> Creating remote working directory ${REMOTE_DIR}"
+firecrest mkdir -p "${REMOTE_DIR}"
+
+echo "==> Uploading build context to ${REMOTE_DIR}"
+firecrest upload "${SCRIPT_DIR}/Containerfile-release" "${REMOTE_DIR}" Containerfile-release
+firecrest mkdir -p "${REMOTE_DIR}/apt-workaround"
+firecrest upload "${SCRIPT_DIR}/apt-workaround/ubuntu.sources" "${REMOTE_DIR}/apt-workaround" ubuntu.sources
+firecrest upload "${SCRIPT_DIR}/apt-workaround/99-jfrog-proxy" "${REMOTE_DIR}/apt-workaround" 99-jfrog-proxy
+firecrest upload "${SCRIPT_DIR}/build-release-lys.sh" "${REMOTE_DIR}" build-release-lys.sh
+
+echo "==> Making remote build script executable"
+firecrest chmod "${REMOTE_DIR}/build-release-lys.sh" 755
+
+echo "==> Submitting remote build job"
+SUBMIT_OUT=$(firecrest submit --working-dir "${REMOTE_DIR}" "remote://${REMOTE_DIR}/build-release-lys.sh")
+echo "${SUBMIT_OUT}"
+
+JOBID=$(echo "${SUBMIT_OUT}" | jq -r '.jobId')
+if [[ -z "${JOBID}" || "${JOBID}" == "null" ]]; then
+    echo "ERROR: failed to extract job ID from submit response" >&2
+    exit 1
+fi
+
+echo "==> Waiting for build job ${JOBID}"
+firecrest wait-for-job "${JOBID}"
+
+echo "==> Downloading build output"
+firecrest download "${REMOTE_DIR}/slurm-${JOBID}.out" "${SCRIPT_DIR}/slurm-${JOBID}.out"
+echo "Build log saved to: ${SCRIPT_DIR}/slurm-${JOBID}.out"
+
+echo "==> Checking for generated image on ${REMOTE_DIR}/ce-images/reframe-release.sqsh"
+firecrest stat "${REMOTE_DIR}/ce-images/reframe-release.sqsh"

--- a/containers/reframe/build-release-lys.sh
+++ b/containers/reframe/build-release-lys.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+#SBATCH --account=csstaff
+#SBATCH --job-name=reframe-build-lys
+#SBATCH --time=01:00:00
+#SBATCH --nodes=1
+
+set -e
+
+# Single scratch prefix for this workflow.  HOST HOME and SCRATCH are left at
+# their host defaults; on lys they resolve to /users/<user> and
+# /vast/scratch/<user> respectively.
+export RFM_LYS_WORKDIR=${SCRATCH}/reframe
+
+# Podman's image storage must be on a local filesystem that supports xattrs;
+# /vast/scratch is a network filesystem and does not.  Use /tmp (tmpfs) for the
+# container storage and runtime files, and keep only the final sqsh on scratch.
+export XDG_RUNTIME_DIR=/tmp/podman-run-${USER}
+export XDG_DATA_HOME=/tmp/podman-data-${USER}
+export XDG_CONFIG_HOME=${RFM_LYS_WORKDIR}/containers/config
+
+mkdir -p "${RFM_LYS_WORKDIR}/.reframe" "${XDG_RUNTIME_DIR}" "${XDG_DATA_HOME}" "${XDG_CONFIG_HOME}"
+
+# Silence the systemd cgroup warning and avoid relying on a user systemd bus.
+mkdir -p "${XDG_CONFIG_HOME}/containers"
+cat > "${XDG_CONFIG_HOME}/containers/containers.conf" <<'EOF'
+[engine]
+cgroup_manager = "cgroupfs"
+EOF
+
+echo "==> Build environment"
+echo "USER=${USER}"
+echo "HOME=${HOME}"
+echo "SCRATCH=${SCRATCH}"
+echo "RFM_LYS_WORKDIR=${RFM_LYS_WORKDIR}"
+echo "XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR}"
+echo "XDG_DATA_HOME=${XDG_DATA_HOME}"
+echo "XDG_CONFIG_HOME=${XDG_CONFIG_HOME}"
+
+echo "==> Checking for container tools"
+which podman >/dev/null || { echo "ERROR: podman not available on this node"; exit 1; }
+which enroot >/dev/null || { echo "ERROR: enroot not available on this node"; exit 1; }
+
+echo "==> Building container image"
+podman build -t localhost/${USER}/reframe:release -f ./Containerfile-release .
+
+echo "==> Importing image to enroot sqsh"
+mkdir -p "${RFM_LYS_WORKDIR}/ce-images"
+rm -f "${RFM_LYS_WORKDIR}/ce-images/reframe-release.sqsh"
+
+# On lys enroot import exits with code 1 even after successfully creating the
+# squashfs image.  Capture the code and verify the artifact explicitly.
+set +e
+enroot import -x mount -o "${RFM_LYS_WORKDIR}/ce-images/reframe-release.sqsh" podman://localhost/${USER}/reframe:release
+ENROOT_EC=$?
+set -e
+
+if [[ ${ENROOT_EC} -ne 0 ]]; then
+    echo "WARNING: enroot import returned exit code ${ENROOT_EC}; verifying artifact" >&2
+fi
+
+if [[ ! -s "${RFM_LYS_WORKDIR}/ce-images/reframe-release.sqsh" ]]; then
+    echo "ERROR: ${RFM_LYS_WORKDIR}/ce-images/reframe-release.sqsh is missing or empty" >&2
+    exit 1
+fi
+
+echo "==> Image created"
+ls -lh "${RFM_LYS_WORKDIR}/ce-images/reframe-release.sqsh"

--- a/containers/reframe/build-release.sh
+++ b/containers/reframe/build-release.sh
@@ -1,5 +1,16 @@
 #!/bin/bash
 
+set -e
+
 podman build -t localhost/${USER}/reframe:release -f ./Containerfile-release .
-rm -f ${SCRATCH}/ce-images/reframe-release.sqsh
-enroot import -x mount -o ${SCRATCH}/ce-images/reframe-release.sqsh podman://localhost/${USER}/reframe:release
+mkdir -p "${SCRATCH}/reframe/ce-images"
+rm -f "${SCRATCH}/reframe/ce-images/reframe-release.sqsh"
+
+enroot import -x mount -o "${SCRATCH}/reframe/ce-images/reframe-release.sqsh" podman://localhost/${USER}/reframe:release
+
+# Place a copy of the environment file next to the image so srun can load it
+# with an absolute ${SCRATCH} path regardless of the submission cwd.
+cp ./reframe.toml "${SCRATCH}/reframe/reframe.toml"
+
+echo "==> Image created"
+ls -lh "${SCRATCH}/reframe/ce-images/reframe-release.sqsh"

--- a/containers/reframe/build-release.sh
+++ b/containers/reframe/build-release.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 podman build -t localhost/${USER}/reframe:release -f ./Containerfile-release .
-rm -f ${SCRATCH}/ce-images/reframe-release.sqfs
-enroot import -x mount -o ${SCRATCH}/ce-images/reframe-release.sqfs podman://localhost/${USER}/reframe:release
+rm -f ${SCRATCH}/ce-images/reframe-release.sqsh
+enroot import -x mount -o ${SCRATCH}/ce-images/reframe-release.sqsh podman://localhost/${USER}/reframe:release

--- a/containers/reframe/deploy-image-to-lys.sh
+++ b/containers/reframe/deploy-image-to-lys.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Fallback local driver script (runs on clariden) that uploads a pre-built
+# enroot sqsh image from clariden to lys via FirecREST/S3 staging.
+
+set -euo pipefail
+
+# PRE-REQ: Load FirecREST environment and CLI.
+
+
+export FIRECREST_SYSTEM=lys
+
+# Derive remote user and scratch path from FirecREST.
+REMOTE_USER=$(firecrest id | awk -F'[()]' '{print $2}')
+REMOTE_SCRATCH=$(firecrest systems | jq -r '.[0].fileSystems[] | select(.dataType=="scratch") | .path')
+REMOTE_DIR="${REMOTE_SCRATCH}/${REMOTE_USER}/reframe"
+LOCAL_IMAGE="${SCRATCH}/reframe/ce-images/reframe-release.sqsh"
+
+echo "==> Checking local image"
+if [[ ! -f "${LOCAL_IMAGE}" ]]; then
+    echo "ERROR: local image not found: ${LOCAL_IMAGE}" >&2
+    echo "Build it first with: ./build-release.sh" >&2
+    exit 1
+fi
+ls -lh "${LOCAL_IMAGE}"
+
+echo "==> Creating remote image directory ${REMOTE_DIR}/ce-images"
+firecrest mkdir -p "${REMOTE_DIR}/ce-images"
+
+echo "==> Uploading image to ${REMOTE_DIR}/ce-images/"
+firecrest upload "${LOCAL_IMAGE}" "${REMOTE_DIR}/ce-images" reframe-release.sqsh
+
+echo "==> Verifying uploaded image"
+firecrest stat "${REMOTE_DIR}/ce-images/reframe-release.sqsh"
+firecrest ls "${REMOTE_DIR}/ce-images"
+
+echo "==> Image deployed to lys: ${REMOTE_DIR}/ce-images/reframe-release.sqsh"

--- a/containers/reframe/reframe.toml
+++ b/containers/reframe/reframe.toml
@@ -1,3 +1,6 @@
-image = "${SCRATCH}/ce-images/reframe-release.sqsh"
-mounts = ["${SCRATCH}:${SCRATCH}", "${HOME}/.reframe:${HOME}/.reframe"]
-workdir = "${SCRATCH}"
+image = "${SCRATCH}/reframe/ce-images/reframe-release.sqsh"
+mounts = [
+    "${SCRATCH}/reframe:${SCRATCH}/reframe",
+    "${SCRATCH}/reframe/.reframe:${HOME}/.reframe"
+]
+workdir = "${SCRATCH}/reframe"

--- a/containers/reframe/reframe.toml
+++ b/containers/reframe/reframe.toml
@@ -1,3 +1,3 @@
 image = "${SCRATCH}/ce-images/reframe-release.sqsh"
-mounts = ["${SCRATCH}:${SCRATCH}", "${HOME}/.reframe:/${HOME}/.reframe"]
+mounts = ["${SCRATCH}:${SCRATCH}", "${HOME}/.reframe:${HOME}/.reframe"]
 workdir = "${SCRATCH}"

--- a/containers/reframe/submit-reframe-clariden.sh
+++ b/containers/reframe/submit-reframe-clariden.sh
@@ -2,7 +2,7 @@
 
 #SBATCH --account=csstaff
 #SBATCH --job-name=test-reframe
-#SBATCH --time=00:10:00
-#SBATCH --nodes=1
+#SBATCH --time=00:30:00
+#SBATCH --nodes=2
 
-srun --environment=./reframe.toml reframe -C /opt/cscs-reframe-tests/config/cscs.py -c /opt/cscs-reframe-tests/checks/ --system clariden:normal -n SlurmGPUGresTest -r
+srun --environment=./reframe.toml reframe -C /opt/cscs-reframe-tests/config/cscs.py -c /opt/cscs-reframe-tests/checks/ --system clariden:normal -n SlurmGPUGresTest -n NCCLTestsCE -n CudaNodeBurnGemmCE -r

--- a/containers/reframe/submit-reframe-clariden.sh
+++ b/containers/reframe/submit-reframe-clariden.sh
@@ -3,6 +3,6 @@
 #SBATCH --account=csstaff
 #SBATCH --job-name=test-reframe
 #SBATCH --time=00:30:00
-#SBATCH --nodes=2
+#SBATCH --nodes=1
 
 srun --environment=./reframe.toml reframe -C /opt/cscs-reframe-tests/config/cscs.py -c /opt/cscs-reframe-tests/checks/ --system clariden:normal -n SlurmGPUGresTest -n NCCLTestsCE -n CudaNodeBurnGemmCE -r

--- a/containers/reframe/submit-reframe-clariden.sh
+++ b/containers/reframe/submit-reframe-clariden.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+#SBATCH --account=csstaff
+#SBATCH --job-name=test-reframe
+#SBATCH --time=00:10:00
+#SBATCH --nodes=1
+
+srun --environment=./reframe.toml reframe -C /opt/cscs-reframe-tests/config/cscs.py -c /opt/cscs-reframe-tests/checks/ --system clariden:normal -n SlurmGPUGresTest -r

--- a/containers/reframe/submit-reframe-clariden.sh
+++ b/containers/reframe/submit-reframe-clariden.sh
@@ -5,4 +5,13 @@
 #SBATCH --time=00:30:00
 #SBATCH --nodes=1
 
-srun --environment=./reframe.toml reframe -C /opt/cscs-reframe-tests/config/cscs.py -c /opt/cscs-reframe-tests/checks/ --system clariden:normal -n SlurmGPUGresTest -n NCCLTestsCE -n CudaNodeBurnGemmCE -r
+mkdir -p "${SCRATCH}/reframe/.reframe"
+
+srun --environment="${SCRATCH}/reframe/reframe.toml" \
+    reframe -C /opt/cscs-reframe-tests/config/cscs.py \
+    -c /opt/cscs-reframe-tests/checks/ \
+    --system clariden:normal \
+    -n SlurmGPUGresTest \
+    -n NCCLTestsCE \
+    -n CudaNodeBurnGemmCE \
+    -r

--- a/containers/reframe/submit-reframe-daint.sh
+++ b/containers/reframe/submit-reframe-daint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+#SBATCH --account=csstaff
+#SBATCH --job-name=test-reframe
+#SBATCH --time=00:10:00
+#SBATCH --nodes=1
+
+srun --environment=./reframe.toml reframe -C /opt/cscs-reframe-tests/config/cscs.py -c /opt/cscs-reframe-tests/checks/ --system daint:normal -n SlurmGPUGresTest -r

--- a/containers/reframe/submit-reframe-lys-firecrest.sh
+++ b/containers/reframe/submit-reframe-lys-firecrest.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #SBATCH --account=csstaff
-#SBATCH --job-name=test-reframe
+#SBATCH --job-name=test-reframe-lys
 #SBATCH --time=00:10:00
 #SBATCH --nodes=1
 
@@ -10,6 +10,6 @@ mkdir -p "${SCRATCH}/reframe/.reframe"
 srun --environment="${SCRATCH}/reframe/reframe.toml" \
     reframe -C /opt/cscs-reframe-tests/config/cscs.py \
     -c /opt/cscs-reframe-tests/checks/ \
-    --system daint:normal \
+    --system lys:normal \
     -n SlurmGPUGresTest \
     -r

--- a/containers/reframe/submit-reframe-lys.sh
+++ b/containers/reframe/submit-reframe-lys.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+#SBATCH --account=csstaff
+#SBATCH --job-name=test-reframe
+#SBATCH --time=00:10:00
+#SBATCH --nodes=1
+
+srun --environment=./reframe.toml reframe -C /opt/cscs-reframe-tests/config/cscs.py -c /opt/cscs-reframe-tests/checks/ --system lys:normal -n SlurmGPUGresTest -r

--- a/containers/reframe/submit-reframe-lys.sh
+++ b/containers/reframe/submit-reframe-lys.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-#SBATCH --account=csstaff
-#SBATCH --job-name=test-reframe
-#SBATCH --time=00:10:00
-#SBATCH --nodes=1
-
-srun --environment=./reframe.toml reframe -C /opt/cscs-reframe-tests/config/cscs.py -c /opt/cscs-reframe-tests/checks/ --system lys:normal -n SlurmGPUGresTest -r

--- a/containers/reframe/test-on-lys.sh
+++ b/containers/reframe/test-on-lys.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Local driver script (runs on clariden) that runs the ReFrame smoke test
+# inside the container on lys via FirecREST.
+
+set -euo pipefail
+
+# PRE-REQ: Load FirecREST environment and CLI.
+
+export FIRECREST_SYSTEM=lys
+
+# Derive remote user and scratch path from FirecREST.
+REMOTE_USER=$(firecrest id | awk -F'[()]' '{print $2}')
+REMOTE_SCRATCH=$(firecrest systems | jq -r '.[0].fileSystems[] | select(.dataType=="scratch") | .path')
+REMOTE_DIR="${REMOTE_SCRATCH}/${REMOTE_USER}/reframe"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "==> Ensuring remote working directory ${REMOTE_DIR} exists"
+firecrest mkdir -p "${REMOTE_DIR}"
+
+echo "==> Uploading test scripts to ${REMOTE_DIR}"
+firecrest upload "${SCRIPT_DIR}/reframe.toml" "${REMOTE_DIR}" reframe.toml
+firecrest upload "${SCRIPT_DIR}/submit-reframe-lys-firecrest.sh" "${REMOTE_DIR}" submit-reframe-lys-firecrest.sh
+
+echo "==> Making remote test script executable"
+firecrest chmod "${REMOTE_DIR}/submit-reframe-lys-firecrest.sh" 755
+
+echo "==> Submitting remote test job"
+SUBMIT_OUT=$(firecrest submit --working-dir "${REMOTE_DIR}" "remote://${REMOTE_DIR}/submit-reframe-lys-firecrest.sh")
+echo "${SUBMIT_OUT}"
+
+JOBID=$(echo "${SUBMIT_OUT}" | jq -r '.jobId')
+if [[ -z "${JOBID}" || "${JOBID}" == "null" ]]; then
+    echo "ERROR: failed to extract job ID from submit response" >&2
+    exit 1
+fi
+
+echo "==> Waiting for test job ${JOBID}"
+firecrest wait-for-job "${JOBID}"
+
+echo "==> Downloading test output"
+firecrest download "${REMOTE_DIR}/slurm-${JOBID}.out" "${SCRIPT_DIR}/slurm-${JOBID}.out"
+echo "Test log saved to: ${SCRIPT_DIR}/slurm-${JOBID}.out"


### PR DESCRIPTION
- Refresh container to fix current issues on Alps 
  - Host compute nodes are SLES 15 SP6 aarch64;
     - Slurm plugins need compatibility symlinks for libdap_r-2.4.so.2, libber-2.4.so.2, libsasl2.so.3 and package libjson-c5.
- Update reframe to latest version
- Validated on Clariden with tests from 
    - https://jira.cscs.ch/browse/VCUE-1288  

```shell
sbatch submit-reframe-clariden.sh
```

