### PR TITLE
Be more specific about which icon uenvs are xfail in UenvFixincludes test

### DIFF
--- a/checks/prgenv/uenv_fixincludes.py
+++ b/checks/prgenv/uenv_fixincludes.py
@@ -7,7 +7,13 @@ import reframe as rfm
 import reframe.utility.sanity as sn
 
 
-@rfm.xfail('ICON uenvs are based on old versions of spack that don\'t fix GCC\'s includes', lambda self: self.current_environ.name.startswith('icon'))  # noqa:E501
+@rfm.xfail(
+    "ICON uenvs are based on old versions of spack that don't fix GCC's includes",
+    lambda self: (
+        self.current_environ.name.startswith("icon_25_2_v4")
+        or self.current_environ.name.startswith("icon-dsl_25_12_v2")
+    ),
+)  # noqa:E501
 @rfm.simple_test
 class UenvFixincludes(rfm.RunOnlyRegressionTest):
     descr = '''

--- a/checks/prgenv/uenv_fixincludes.py
+++ b/checks/prgenv/uenv_fixincludes.py
@@ -10,8 +10,8 @@ import reframe.utility.sanity as sn
 @rfm.xfail(
     "ICON uenvs are based on old versions of spack that don't fix GCC's includes",
     lambda self: (
-        self.current_environ.name.startswith("icon_25_2_v4")
-        or self.current_environ.name.startswith("icon-dsl_25_12_v2")
+        self.current_environ.name.startswith("icon_25.2_v4")
+        or self.current_environ.name.startswith("icon-dsl_25.12_v2")
     ),
 )  # noqa:E501
 @rfm.simple_test


### PR DESCRIPTION
The latest icon uenv now passes the UenvFixincludes test, so the test was XPASSing at the latest maintenance reframe run. This PR updates the xfail condition to specifically xfail only the icon* uenvs that should be xfailed. New versions of the icon uenvs are not automatically xfailed anymore.

Tested on santis with `CSCS_RFM_UENV=icon/25.2:v1,icon/25.2:v3,icon/25.2:v4,icon/26.7:v1,icon-dsl/25.12:v1,icon-dsl/25.12:v2,icon-wcp/v1:rc4 reframe -C $PWD/config/cscs.py --system santis -c checks/prgenv/uenv_fixincludes.py --run`.