### PR TITLE
pin reframe to 4.9.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-reframe-hpc>=4.9.0
+reframe-hpc==4.9.3
 packaging


### PR DESCRIPTION
pin reframe to 4.9.3 to avoid the following error caused by reframe 4.10.1:

```
[daint][simonpi@daint-ln002 ~]$ echo $CSCS_RFM_UENV
quantumespresso/v7.5:v2
[daint][simonpi@daint-ln002 ~]$   reframe -vv \
>       -C cscs-reframe-tests/config/cscs.py \
>           -c cscs-reframe-tests/checks/apps/quantumespresso/quantumespresso_check_uenv.py \
>           -l \
>           --keep-stage-files
...
On instance['environments'][10]['name']:
    'quantumespresso_v7.5_v2_modules'
ERROR: failed to load configuration: could not validate configuration files: `<builtin>`, `/users/simonpi/cscs-reframe-tests/config/cscs.py`: 'quantumespresso_v7.5_v2_modules' does not match '^[a-zA-Z_](?:[a-zA-Z0-9_-])*$'
```
https://github.com/eth-cscs/uenv-pipeline relies on `requirements.txt` and currently runs into the same error in https://github.com/eth-cscs/alps-uenv

See for example here:
https://gitlab.com/cscs-ci/ci-testing/webhook-ci/mirrors/551234120955960/1440398897047560/-/jobs/15446902202