### PR TITLE
extras.version for UENV

### DIFF
--- a/config/utilities/uenv.py
+++ b/config/utilities/uenv.py
@@ -403,7 +403,8 @@ def _get_uenvs() -> Optional[List]:
             )
             env['name'] = f'{uenv_name_pretty}_{k}'
 
-            env.setdefault("extras", {})["version"] = _uenv_version_and_tag_from_label(uenv_name)
+            if not env.get('extras', {}).get('version'):
+                env.setdefault("extras", {})["version"] = _uenv_version_and_tag_from_label(uenv_name)
 
             env['resources'] = {
                 'uenv': {


### PR DESCRIPTION
If `CSCS_RFM_UENV` is provided as sqfs path, the version lookup fails. Most uenvs provide `extras.version` in `reframe.yaml`, try to obtain the version from uenv name only if that entry is missing.