### PR TITLE
Fix for InvalidVersion

### DIFF
--- a/checks/apps/cp2k/cp2k_uenv.py
+++ b/checks/apps/cp2k/cp2k_uenv.py
@@ -11,10 +11,8 @@ import reframe as rfm
 import reframe.utility.sanity as sn
 from packaging.version import Version
 from reframe.core.builtins import xfail
-from reframe.utility import udeps
+import reframe.utility.udeps as udeps
 from uenv import uarch
-
-# import reframe.utility.udeps as udeps
 
 cp2k_references = {
     'md': {

--- a/checks/apps/cp2k/cp2k_uenv.py
+++ b/checks/apps/cp2k/cp2k_uenv.py
@@ -348,12 +348,13 @@ class Cp2kCheckMD_UENVCustomExec(Cp2kCheckMD_UENV):
 # {{{ PBE
 class Cp2kCheckPBE_UENV(Cp2kCheck_UENV):
     """
-cp2k/2024.2:v1 no rfm
-cp2k/2024.3:v1 no rfm
-cp2k/2024.3:v2 env.extras.version=('2024.3', 'v2')
-cp2k/2025.1:v2 env.extras.version=('2025.1', 'v2')
-cp2k/2026.1:v1 env.extras.version=v2026.1
-cp2k/2026.1:v2 env.extras.version=v2026.1
+Included versions:
+    cp2k/2024.2:v1 no rfm
+    cp2k/2024.3:v1 no rfm
+    cp2k/2024.3:v2 env.extras.version=('2024.3', 'v2')
+    cp2k/2025.1:v2 env.extras.version=('2025.1', 'v2')
+    cp2k/2026.1:v1 env.extras.version=v2026.1
+    cp2k/2026.1:v2 env.extras.version=v2026.1
     """
     test_name = 'pbe'
     valid_prog_environs = ['+cp2k -dlaf']
@@ -371,12 +372,12 @@ cp2k/2026.1:v2 env.extras.version=v2026.1
             uenv_version = (
                 uenv_version[0]
                 if isinstance(uenv_version, tuple)
-                else uenv_version.replace('v', '')
+                else uenv_version.lstrip('v')
             )
         except (KeyError, AttributeError):
             uenv_version = version_from_uenv()
 
-        if Version(uenv_version[1:]) > Version('2025.1'):
+        if Version(uenv_version) > Version('2025.1'):
             # Reduce max_scf to 16 to reproduce previous behaviour
             self.executable_opts = ['-i', 'H2O-128-PBE-TZ-max_scf_16.inp']
         else:

--- a/checks/apps/cp2k/cp2k_uenv.py
+++ b/checks/apps/cp2k/cp2k_uenv.py
@@ -347,6 +347,14 @@ class Cp2kCheckMD_UENVCustomExec(Cp2kCheckMD_UENV):
 
 # {{{ PBE
 class Cp2kCheckPBE_UENV(Cp2kCheck_UENV):
+    """
+cp2k/2024.2:v1 no rfm
+cp2k/2024.3:v1 no rfm
+cp2k/2024.3:v2 env.extras.version=('2024.3', 'v2')
+cp2k/2025.1:v2 env.extras.version=('2025.1', 'v2')
+cp2k/2026.1:v1 env.extras.version=v2026.1
+cp2k/2026.1:v2 env.extras.version=v2026.1
+    """
     test_name = 'pbe'
     valid_prog_environs = ['+cp2k -dlaf']
     energy_reference = -2206.2426491358
@@ -359,11 +367,16 @@ class Cp2kCheckPBE_UENV(Cp2kCheck_UENV):
         # a different count means a different runtime with the same input file
         # See https://github.com/cp2k/cp2k/pull/4141
         try:
-            uenv_version = self.current_environ.extras['version'][0]
+            uenv_version = self.current_environ.extras['version']
+            uenv_version = (
+                uenv_version[0]
+                if isinstance(uenv_version, tuple)
+                else uenv_version.replace('v', '')
+            )
         except (KeyError, AttributeError):
             uenv_version = version_from_uenv()
 
-        if Version(uenv_version) > Version('2025.1'):
+        if Version(uenv_version[1:]) > Version('2025.1'):
             # Reduce max_scf to 16 to reproduce previous behaviour
             self.executable_opts = ['-i', 'H2O-128-PBE-TZ-max_scf_16.inp']
         else:

--- a/checks/apps/cp2k/cp2k_uenv.py
+++ b/checks/apps/cp2k/cp2k_uenv.py
@@ -4,15 +4,17 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import os
-import shutil
-from packaging.version import Version
 import re
+import shutil
 
 import reframe as rfm
 import reframe.utility.sanity as sn
-import reframe.utility.udeps as udeps
+from packaging.version import Version
 from reframe.core.builtins import xfail
+from reframe.utility import udeps
 from uenv import uarch
+
+# import reframe.utility.udeps as udeps
 
 cp2k_references = {
     'md': {


### PR DESCRIPTION
- [x]  the cp2k test does not like the change introduced in https://github.com/eth-cscs/cscs-reframe-tests/pull/631, this PR will fix it

```
  * Reason: invalid version: Invalid version: 'v':
| /usr/lib/python3.11/site-packages/packaging/version.py:198
|             raise InvalidVersion(f"Invalid version: '{version}'")
```

version is set  in reframe.yaml:

```
cp2k/2024.3:v2 env.extras.version=('2024.3', 'v2')
cp2k/2025.1:v2 env.extras.version=('2025.1', 'v2')
cp2k/2026.1:v1 env.extras.version=v2026.1
cp2k/2026.1:v2 env.extras.version=v2026.1
```