### PR TITLE
Fix version extraction in cp2k and qe download

### DIFF
--- a/checks/apps/cp2k/cp2k_uenv.py
+++ b/checks/apps/cp2k/cp2k_uenv.py
@@ -107,11 +107,10 @@ class cp2k_download(rfm.RunOnlyRegressionTest):
     def set_version(self):
         try:
             uenv_version = self.current_environ.extras['version']
-            uenv_version = (
-                uenv_version[0]
-                if isinstance(uenv_version, tuple)
-                else uenv_version.lstrip('v')
-            )
+            if isinstance(uenv_version, tuple):
+                uenv_version = uenv_version[0]
+            if isinstance(uenv_version, str):
+                uenv_version = uenv_version.lstrip('v')
         except (KeyError, AttributeError):
             uenv_version = version_from_uenv()
 

--- a/checks/apps/cp2k/cp2k_uenv.py
+++ b/checks/apps/cp2k/cp2k_uenv.py
@@ -106,7 +106,12 @@ class cp2k_download(rfm.RunOnlyRegressionTest):
     @run_before('run')
     def set_version(self):
         try:
-            uenv_version = self.current_environ.extras['version'][0]
+            uenv_version = self.current_environ.extras['version']
+            uenv_version = (
+                uenv_version[0]
+                if isinstance(uenv_version, tuple)
+                else uenv_version.lstrip('v')
+            )
         except (KeyError, AttributeError):
             uenv_version = version_from_uenv()
 

--- a/checks/apps/quantumespresso/quantumespresso_check_uenv.py
+++ b/checks/apps/quantumespresso/quantumespresso_check_uenv.py
@@ -63,7 +63,11 @@ class qe_download(rfm.RunOnlyRegressionTest):
     def set_version(self):
 
         try:
-            uenv_version = self.current_environ.extras['version'][0].lstrip('v')
+            uenv_version = self.current_environ.extras['version']
+            if isinstance(uenv_version, tuple):
+                uenv_version = uenv_version[0]
+            if isinstance(uenv_version, str):
+                uenv_version = uenv_version.lstrip('v')
         except (KeyError, AttributeError):
             self.logger.debug("Key ERROR: version from uenv!!")
             uenv_version = version_from_uenv()


### PR DESCRIPTION
Handle both tuple and string formats for extras['version'] in CP2K and QuantumESPRESSO download checks, stripping any leading v to construct the correct source archive URL.

This fixes the broken download URL (vv.tar.gz) observed with CP2K 2026.1 uenvs, where the version is stored as a string rather than a tuple.

```shell
cscs-ci run alps-daint-uenv;CSCS_RFM_UENV=cp2k
```
