### PR TITLE
update tests after eiger upgrade

### DIFF
--- a/checks/system/integration/alps.py
+++ b/checks/system/integration/alps.py
@@ -282,15 +282,8 @@ def create_checks(check):
         'slingshot-show-cxi-iommu-group | grep type=identity | wc -l',
         name='slingshot-iommu-group',
         descr='Verify CXI IOMMU group is set to identity on all NICs',
-        valid_systems=['daint', 'santis', 'clariden'],
+        valid_systems=['daint', 'santis', 'clariden', 'eiger'],
         expected=r'4'
-    )
-    check(
-        'grep -q "iommu.passthrough=y"  /proc/cmdline || echo FAILED',
-        name='slingshot-iommu-passthrough',
-        descr='Verify IOMMU pass through is enabled on Eiger',
-        valid_systems=['eiger'],
-        not_expected=r'FAILED'
     )
 
     # ----------------------------------------------------------------------- #
@@ -329,17 +322,10 @@ def create_checks(check):
 
     check(
         'cat /etc/os-release',
-        name='os-version-check-daint',
+        name='os-version-check',
         descr='Verify SUSE Linux Enterprise Server 15 SP6 is installed',
-        valid_systems=['daint', 'santis', 'clariden'],
+        valid_systems=['daint', 'santis', 'clariden', 'eiger'],
         expected=r'PRETTY_NAME="SUSE Linux Enterprise Server 15 SP6"'
-    )
-    check(
-        'cat /etc/os-release',
-        name='os-version-check-eiger',
-        descr='Verify SUSE Linux Enterprise Server 15 SP5 is installed (Eiger)',
-        valid_systems=['eiger'],
-        expected=r'PRETTY_NAME="SUSE Linux Enterprise Server 15 SP5"'
     )
     check(
         'cat /etc/locale.conf',
@@ -469,27 +455,6 @@ def create_checks(check):
         'grep -q "/users/cscs /users nfs"                 /proc/mounts || echo FAILED',
         name='mount-users-eiger',
         descr='Verify /users NFS mount (Eiger)',
-        valid_systems=['eiger'],
-        not_expected=r'FAILED'
-    )
-    check(
-        'grep -q "pe_opt_cray_pe /opt/cray/pe"  /proc/mounts || echo FAILED',
-        name='mount-cray-pe-eiger',
-        descr='Verify Cray PE mount (Eiger)',
-        valid_systems=['eiger'],
-        not_expected=r'FAILED'
-    )
-    check(
-        'grep -q "pe_opt_AMD /opt/AMD"          /proc/mounts || echo FAILED',
-        name='mount-amd-eiger',
-        descr='Verify AMD module mount (Eiger)',
-        valid_systems=['eiger'],
-        not_expected=r'FAILED'
-    )
-    check(
-        'grep -q "pe_opt_intel /opt/intel"      /proc/mounts || echo FAILED',
-        name='mount-intel-eiger',
-        descr='Verify Intel module mount (Eiger)',
         valid_systems=['eiger'],
         not_expected=r'FAILED'
     )
@@ -803,7 +768,6 @@ def create_checks(check):
         descr='Verify system libfabric host directory is present',
         valid_systems=['daint', 'eiger', 'santis', 'clariden'],
         not_expected=r'FAILED',
-        xfail=('Missing host directory on Eiger', lambda test: test.current_system.name == 'eiger'),
     )
 
     # ----------------------------------------------------------------------- #

--- a/checks/system/integration/alps.py
+++ b/checks/system/integration/alps.py
@@ -282,8 +282,15 @@ def create_checks(check):
         'slingshot-show-cxi-iommu-group | grep type=identity | wc -l',
         name='slingshot-iommu-group',
         descr='Verify CXI IOMMU group is set to identity on all NICs',
-        valid_systems=['daint', 'santis', 'clariden', 'eiger'],
+        valid_systems=['daint', 'santis', 'clariden'],
         expected=r'4'
+    )
+    check(
+        'slingshot-show-cxi-iommu-group | grep type=identity | wc -l',
+        name='slingshot-iommu-group',
+        descr='Verify CXI IOMMU group is set to identity on all NICs',
+        valid_systems=['eiger'],
+        expected=r'1'
     )
 
     # ----------------------------------------------------------------------- #

--- a/checks/system/integration/alps.py
+++ b/checks/system/integration/alps.py
@@ -287,7 +287,7 @@ def create_checks(check):
     )
     check(
         'slingshot-show-cxi-iommu-group-eiger | grep type=identity | wc -l',
-        name='slingshot-iommu-group',
+        name='slingshot-iommu-group-eiger',
         descr='Verify CXI IOMMU group is set to identity on all NICs',
         valid_systems=['eiger'],
         expected=r'1'

--- a/checks/system/integration/alps.py
+++ b/checks/system/integration/alps.py
@@ -286,7 +286,7 @@ def create_checks(check):
         expected=r'4'
     )
     check(
-        'slingshot-show-cxi-iommu-group-eiger | grep type=identity | wc -l',
+        'slingshot-show-cxi-iommu-group| grep type=identity | wc -l',
         name='slingshot-iommu-group-eiger',
         descr='Verify CXI IOMMU group is set to identity on all NICs',
         valid_systems=['eiger'],

--- a/checks/system/integration/alps.py
+++ b/checks/system/integration/alps.py
@@ -286,7 +286,7 @@ def create_checks(check):
         expected=r'4'
     )
     check(
-        'slingshot-show-cxi-iommu-group | grep type=identity | wc -l',
+        'slingshot-show-cxi-iommu-group-eiger | grep type=identity | wc -l',
         name='slingshot-iommu-group',
         descr='Verify CXI IOMMU group is set to identity on all NICs',
         valid_systems=['eiger'],


### PR DESCRIPTION
Fix all failing tests after eiger upgrade. That's the list of failing tests:
```
sanity        12    slingshot-iommu-passthrough @eiger:login+builtin
                    slingshot-iommu-passthrough @eiger:normal+builtin
                    os-version-check-eiger @eiger:login+builtin
                    os-version-check-eiger @eiger:normal+builtin
                    mount-cray-pe-eiger @eiger:login+builtin
                    mount-cray-pe-eiger @eiger:normal+builtin
                    mount-amd-eiger @eiger:login+builtin
                    mount-amd-eiger @eiger:normal+builtin
                    mount-intel-eiger @eiger:login+builtin
                    mount-intel-eiger @eiger:normal+builtin
                    libfabric-host-directory @eiger:login+builtin
                    libfabric-host-directory @eiger:normal+builtin
```
We should either do the same test as on `daint`, or drop the test (e.g. all CPE tests).