### PR TITLE
Add --gpus-per-node=4

### DIFF
--- a/config/systems/santis.py
+++ b/config/systems/santis.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+ Copyright 2024 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause
@@ -34,7 +34,9 @@ site_configuration = {
                     'name': 'normal',
                     'scheduler': 'slurm',
                     'time_limit': '10m',
-                    'environs': [
+                    'envir,
+                        f'--gpus-per-node=4'
+                    ons': [
                         'builtin',
                     ],
                     'max_jobs': 1000,
@@ -51,8 +53,12 @@ site_configuration = {
                             'options': ['--gres={gres}']
                         },
                     ],
-                    'features': ['ce', 'gpu', 'nvgpu', 'remote', 'scontrol', 'uenv', 'hugepages_slurm'],
-                    'access': [f'--account={osext.osgroup()}'],
+                    'features': ['ce', 'gpu', 'nvgpu', 'remote', 'scontrol', 
+                                 'uenv', 'hugepages_slurm'],
+                    'access': [
+                        f'--account={osext.osgroup()}',
+                        f'--gpus-per-node=4'
+                    ],
                     'devices': [
                         {
                             'type': 'gpu',

--- a/config/systems/santis.py
+++ b/config/systems/santis.py
@@ -1,4 +1,4 @@
- Copyright 2024 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause
@@ -34,9 +34,7 @@ site_configuration = {
                     'name': 'normal',
                     'scheduler': 'slurm',
                     'time_limit': '10m',
-                    'envir,
-                        f'--gpus-per-node=4'
-                    ons': [
+                    'environs': [
                         'builtin',
                     ],
                     'max_jobs': 1000,
@@ -54,7 +52,8 @@ site_configuration = {
                         },
                     ],
                     'features': ['ce', 'gpu', 'nvgpu', 'remote', 'scontrol', 
-                                 'uenv', 'hugepages_slurm'],
+                                 'uenv', 'hugepages_slurm'
+                    ],
                     'access': [
                         f'--account={osext.osgroup()}',
                         f'--gpus-per-node=4'


### PR DESCRIPTION
- [x] Adjust ReFrame config of Säntis to reflect the newly deployed node-sharing configuration of SLURM.

When ready, manually trigger 1 (or more) CI pipelines by writing a cscs-ci
comment inside this Pull Request. For instance:

```shell
cscs-ci run alps-daint-uenv;CSCS_RFM_UENV=prgenv-gnu/26.3:v1
cscs-ci run alps-santis-uenv;CSCS_RFM_UENV=prgenv-gnu/26.3:v1
cscs-ci run alps-clariden-uenv;CSCS_RFM_UENV=prgenv-gnu/26.3:v1

cscs-ci run alps-starlex-uenv;CSCS_RFM_UENV=prgenv-gnu/26.3:v1
cscs-ci run alps-beverin-uenv;CSCS_RFM_UENV=prgenv-gnu/25.07-6.3.3:v12

cscs-ci run alps-eiger-uenv;CSCS_RFM_UENV=[build::|service::]prgenv-gnu/26.3:v1
cscs-ci run alps-pilatus-uenv;CSCS_RFM_UENV=[build::|service::]prgenv-gnu/26.3:v1
```

- You can also pass SLURM flags:
    - cscs-ci run alps-starlex-uenv;CSCS_RFM_UENV=prgenv-gnu/25.11:v1;CSCS_RFM_EXTRA="-J reservation=uss140-shs131-nv590-staging"
    - note:
        - the group of the reframe user currently is djenkssl, not csstaff, check the allowed groups in the reservation,
        - the default SLURM_TIMELIMIT is set to 2h, check the allowed MaxTime in the partition.
