### PR TITLE
Update cuda_samples test

### DIFF
--- a/checks/prgenv/cuda/cuda_samples.py
+++ b/checks/prgenv/cuda/cuda_samples.py
@@ -7,18 +7,20 @@ import reframe as rfm
 import reframe.utility.sanity as sn
 
 
+keep_files = {
+    'deviceQuery': 'cuda-samples/Samples/1_Utilities/deviceQuery',
+    'simpleCUBLAS': 'cuda-samples/Samples/4_CUDA_Libraries/simpleCUBLAS'
+}
+
+
 class CudaSamplesBase(rfm.RegressionTest):
-    sourcesdir = 'https://github.com/NVIDIA/cuda-samples.git'
+    repo = 'https://github.com/NVIDIA/cuda-samples.git'
+    sourcesdir = 'src/cuda_samples'
     build_system = 'CMake'
     build_locally = False
     time_limit = '2m'
     maintainers = ['PA', 'SSA']
-    sample = parameter([
-        'deviceQuery', 'simpleCUBLAS', 'conjugateGradient'
-    ])
-    # https://github.com/NVIDIA/cuda-samples/releases/tag/v12.8
-    #   concurrentKernels is osbsolete since cuda/12.8
-    #   bandwidthTest is osbsolete since cuda/12.9
+    sample = parameter(['deviceQuery', 'simpleCUBLAS'])
     tags = {'production'}
 
     @run_after('init')
@@ -26,28 +28,24 @@ class CudaSamplesBase(rfm.RegressionTest):
         self.descr = f'CUDA {self.sample} test'
 
     @run_before('compile')
-    def set_branch(self):
-        self.prebuild_cmds += [
-            # Retrieve the CUDA version from nvcc and checkout tag
-            rf"export CUDA_VER=v$(nvcc -V | "
-            rf"sed -n 's/^.*release \([[:digit:]]*\.[[[:digit:]]\).*$/\1/p')",
-            #
-            # The tags v12.[6-7] do not exist, checkout v12.8 instead
-            rf"[[ $CUDA_VER = 'v12.6' || $CUDA_VER = 'v12.7' ]] && "
-            rf"export CUDA_VER='v12.8'",
-            #
-            rf"echo CUDA_VER=$CUDA_VER",
-            rf"git checkout ${{CUDA_VER}}",
-        ]
-
-    @run_before('compile')
     def set_gpu_arch(self):
         gpu_arch = self.current_partition.select_devices('gpu')[0].arch[3:]
+        self.build_system.srcdir = 'cuda-samples'
+        self.build_system.configuredir = keep_files[self.sample]
+        self.build_system.builddir = f'_build'
         self.build_system.config_opts += [
-            f'-S Samples',
             f'-DCMAKE_CUDA_ARCHITECTURES={gpu_arch}',
         ]
-        self.build_system.make_opts = [self.sample]
+        self.build_system.build_opts = [self.sample]
+
+    @run_before('compile')
+    def set_branch(self):
+        self.prebuild_cmds += [
+            rf'git clone --quiet {self.repo}',
+            rf'./_git_checkout.sh {self.build_system.srcdir}',
+            # trying to save disk space for daily runs:
+            rf'./_clean.sh {keep_files[self.sample]}'
+        ]
 
     @run_before('run')
     def set_executable(self):
@@ -58,8 +56,6 @@ class CudaSamplesBase(rfm.RegressionTest):
         output_patterns = {
             'deviceQuery': r'Result = PASS',
             'simpleCUBLAS': r'test passed',
-            'conjugateGradient':
-                r'Test Summary:  Error amount = 0.00000'
         }
         self.sanity_patterns = sn.assert_found(
             output_patterns[self.sample], self.stdout
@@ -70,9 +66,7 @@ class CudaSamplesBase(rfm.RegressionTest):
 class UENV_CudaSamples(CudaSamplesBase):
     valid_systems = ['+nvgpu']
     valid_prog_environs = ['+uenv +prgenv +cuda -cpe']
-    # env_vars = {'LD_LIBRARY_PATH': '$CUDA_HOME/lib64:$LD_LIBRARY_PATH'}
 
     @run_before('compile')
     def set_build_flags(self):
         self.prebuild_cmds += ['echo CUDA_HOME=$CUDA_HOME']
-        # self.build_system.options += [f'CUDA_PATH=$CUDA_HOME']

--- a/checks/prgenv/cuda/cuda_samples.py
+++ b/checks/prgenv/cuda/cuda_samples.py
@@ -20,7 +20,7 @@ class CudaSamplesBase(rfm.RegressionTest):
     @run_after('init')
     def set_descr(self):
         self.descr = f'CUDA {self.sample} test'
-        self.keep_files = {
+        self.keep_files_d = {
             'deviceQuery': 'cuda-samples/Samples/1_Utilities/deviceQuery',
             'simpleCUBLAS':
                 'cuda-samples/Samples/4_CUDA_Libraries/simpleCUBLAS'
@@ -30,7 +30,7 @@ class CudaSamplesBase(rfm.RegressionTest):
     def set_gpu_arch(self):
         gpu_arch = self.current_partition.select_devices('gpu')[0].arch[3:]
         self.build_system.srcdir = 'cuda-samples'
-        self.build_system.configuredir = self.keep_files[self.sample]
+        self.build_system.configuredir = self.keep_files_d[self.sample]
         self.build_system.builddir = f'_build'
         self.build_system.config_opts += [
             f'-DCMAKE_CUDA_ARCHITECTURES={gpu_arch}',
@@ -44,7 +44,7 @@ class CudaSamplesBase(rfm.RegressionTest):
             rf'git clone --quiet {self.repo}',
             rf'./_git_checkout.sh {self.build_system.srcdir}',
             # trying to save disk space for daily runs:
-            rf'./_clean.sh {self.keep_files[self.sample]}'
+            rf'./_clean.sh {self.keep_files_d[self.sample]}'
         ]
 
     @run_before('run')

--- a/checks/prgenv/cuda/cuda_samples.py
+++ b/checks/prgenv/cuda/cuda_samples.py
@@ -7,12 +7,6 @@ import reframe as rfm
 import reframe.utility.sanity as sn
 
 
-keep_files = {
-    'deviceQuery': 'cuda-samples/Samples/1_Utilities/deviceQuery',
-    'simpleCUBLAS': 'cuda-samples/Samples/4_CUDA_Libraries/simpleCUBLAS'
-}
-
-
 class CudaSamplesBase(rfm.RegressionTest):
     repo = 'https://github.com/NVIDIA/cuda-samples.git'
     sourcesdir = 'src/cuda_samples'
@@ -22,6 +16,10 @@ class CudaSamplesBase(rfm.RegressionTest):
     maintainers = ['PA', 'SSA']
     sample = parameter(['deviceQuery', 'simpleCUBLAS'])
     tags = {'production'}
+    keep_files = {
+        'deviceQuery': 'cuda-samples/Samples/1_Utilities/deviceQuery',
+        'simpleCUBLAS': 'cuda-samples/Samples/4_CUDA_Libraries/simpleCUBLAS'
+    }
 
     @run_after('init')
     def set_descr(self):
@@ -31,7 +29,7 @@ class CudaSamplesBase(rfm.RegressionTest):
     def set_gpu_arch(self):
         gpu_arch = self.current_partition.select_devices('gpu')[0].arch[3:]
         self.build_system.srcdir = 'cuda-samples'
-        self.build_system.configuredir = keep_files[self.sample]
+        self.build_system.configuredir = self.keep_files[self.sample]
         self.build_system.builddir = f'_build'
         self.build_system.config_opts += [
             f'-DCMAKE_CUDA_ARCHITECTURES={gpu_arch}',
@@ -40,11 +38,12 @@ class CudaSamplesBase(rfm.RegressionTest):
 
     @run_before('compile')
     def set_branch(self):
+        # every job has a separate directory, cloning inside each dir is fine
         self.prebuild_cmds += [
             rf'git clone --quiet {self.repo}',
             rf'./_git_checkout.sh {self.build_system.srcdir}',
             # trying to save disk space for daily runs:
-            rf'./_clean.sh {keep_files[self.sample]}'
+            rf'./_clean.sh {self.keep_files[self.sample]}'
         ]
 
     @run_before('run')

--- a/checks/prgenv/cuda/cuda_samples.py
+++ b/checks/prgenv/cuda/cuda_samples.py
@@ -16,14 +16,15 @@ class CudaSamplesBase(rfm.RegressionTest):
     maintainers = ['PA', 'SSA']
     sample = parameter(['deviceQuery', 'simpleCUBLAS'])
     tags = {'production'}
-    keep_files = {
-        'deviceQuery': 'cuda-samples/Samples/1_Utilities/deviceQuery',
-        'simpleCUBLAS': 'cuda-samples/Samples/4_CUDA_Libraries/simpleCUBLAS'
-    }
 
     @run_after('init')
     def set_descr(self):
         self.descr = f'CUDA {self.sample} test'
+        self.keep_files = {
+            'deviceQuery': 'cuda-samples/Samples/1_Utilities/deviceQuery',
+            'simpleCUBLAS':
+                'cuda-samples/Samples/4_CUDA_Libraries/simpleCUBLAS'
+        }
 
     @run_before('compile')
     def set_gpu_arch(self):

--- a/checks/prgenv/cuda/src/cuda_samples/_clean.sh
+++ b/checks/prgenv/cuda/src/cuda_samples/_clean.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+dirn=$1
+# example: 'cuda-samples/Samples/1_Utilities/deviceQuery'
+if [ -z $dirn ] ; then exit -1 ; else echo "cleaning $dirn" ; fi
+
+rm -fr cuda-samples/bin/win64
+
+# --- level1
+_wdir=$(echo $dirn |cut -d/ -f1,2) # cuda-samples/Samples/
+_keep=$(echo $dirn |cut -d/ -f3)  # 1_Utilities
+cd $_wdir
+_delete=$(ls -I CMakeLists.txt -I $_keep)
+_cmd="rm -fr $_delete"
+echo $_cmd
+$_cmd
+cd -
+
+# --- level2
+_wdir=$(echo $dirn |cut -d/ -f1,2,3) # cuda-samples/Samples/1_Utilities/
+_keep=$(echo $dirn |cut -d/ -f4)     # deviceQuery
+cd $_wdir
+_delete=$(ls -I CMakeLists.txt -I $_keep)
+_cmd="rm -fr $_delete"
+echo $_cmd
+$_cmd
+cd -
+

--- a/checks/prgenv/cuda/src/cuda_samples/_clean.sh
+++ b/checks/prgenv/cuda/src/cuda_samples/_clean.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 
+# this script will keep the minimum amount of files,
+# it can be improved but this will do the job as is.
+
 dirn=$1
 # example: 'cuda-samples/Samples/1_Utilities/deviceQuery'
-if [ -z $dirn ] ; then exit -1 ; else echo "cleaning $dirn" ; fi
+if [ -z "$dirn" ] ; then exit -1 ; else echo "cleaning $dirn" ; fi
 
 rm -fr cuda-samples/bin/win64
 

--- a/checks/prgenv/cuda/src/cuda_samples/_git_checkout.sh
+++ b/checks/prgenv/cuda/src/cuda_samples/_git_checkout.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+in=$1
+if [ -z $in ] ; then exit -1 ; fi
+
+cd $in
+
+# Retrieve the CUDA version from nvcc and checkout matching tag
+export CUDA_VER=v$(nvcc -V | sed -n 's/^.*release \([[:digit:]]*\.[[[:digit:]]\).*$/\1/p')
+
+# tags v12.[6-7] do not exist, checkout v12.8 instead
+[[ $CUDA_VER = 'v12.6' || $CUDA_VER = 'v12.7' ]] && export CUDA_VER='v12.8'
+
+echo CUDA_VER=$CUDA_VER
+git checkout ${CUDA_VER}
+
+cd -

--- a/checks/prgenv/cuda/src/cuda_samples/_git_checkout.sh
+++ b/checks/prgenv/cuda/src/cuda_samples/_git_checkout.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 
-in=$1
-if [ -z $in ] ; then exit -1 ; fi
+# will checkout the tag matching the version of cuda in the uenv
+# tested with 12.9 and 13.1, will revisit when getting new uenvs
 
-cd $in
+in=$1
+if [ -z "$in" ] ; then exit -1 ; else cd $in ; fi
 
 # Retrieve the CUDA version from nvcc and checkout matching tag
-export CUDA_VER=v$(nvcc -V | sed -n 's/^.*release \([[:digit:]]*\.[[[:digit:]]\).*$/\1/p')
-
-# tags v12.[6-7] do not exist, checkout v12.8 instead
-[[ $CUDA_VER = 'v12.6' || $CUDA_VER = 'v12.7' ]] && export CUDA_VER='v12.8'
+CUDA_VER=v$(nvcc -V | sed -n 's/^.*release \([[:digit:]]*\.[[[:digit:]]\).*$/\1/p')
+# for reference, tags v12.[6-7] do not exist, checkout v12.8 instead
+[[ "$CUDA_VER" = 'v12.6' || "$CUDA_VER" = 'v12.7' ]] && export CUDA_VER='v12.8'
 
 echo CUDA_VER=$CUDA_VER
 git checkout ${CUDA_VER}


### PR DESCRIPTION
- [x] https://confluence.cscs.ch/spaces/reframe/pages/1077611096/RFM+2026-09-03

The PR refactors the cuda_samples ReFrame test to reduce disk/inode usage by:
- Moving from ReFrame-managed cloning of NVIDIA/cuda-samples to a manual git clone + cleanup in prebuild_cmds.
- Adding two helper scripts (_git_checkout.sh, _clean.sh) under checks/prgenv/cuda/src/cuda_samples/.
- Dropping the conjugateGradient sample and keeping only deviceQuery and simpleCUBLAS.
- Switching from deprecated make_opts to build_opts.
General assessment