### PR TITLE
uenv: fix problem when system is specified for a uenv

### DIFF
--- a/config/utilities/uenv.py
+++ b/config/utilities/uenv.py
@@ -401,6 +401,7 @@ def _get_uenvs() -> Optional[List]:
                 .replace("/", "_")
                 .replace("%", "_")
                 .replace(".", "_")
+                .replace("@", "_") # _UENV_CLI_SYSTEM_DELIMITER
             )
             env['name'] = f'{uenv_name_pretty}_{k}'
 


### PR DESCRIPTION
According to error message, `@` is not among accepted symbols for configuration name

```
$ CSCS_RFM_UENV=linalg/25.10:v1+daint reframe -C config/cscs.py -c checks/libraries/dlaf/ --keep-stage-files -r
WARNING: redefinition of environment '*:builtin': already defined in '<builtin>'
ERROR: failed to load configuration: could not validate configuration files: `<builtin>`, `/capstor/store/cscs/cscs/csstaff/ialberto/workspace/cscs-reframe-tests/config/cscs.py`: 'linalg_25_10_v1@daint_run' does not match '^[a-zA-Z_](?:[a-zA-Z0-9_-])*$'
Log file(s) saved in '/tmp/rfm-2hxn5fan.log'
```

Not sure if I'm doing something wrong, nor if the fix makes sense (symbol management is a bit tricky), I look forward to the review from you experts of this codebase.